### PR TITLE
修复短链接失效

### DIFF
--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -539,15 +539,13 @@ export class HttpApiService {
     async createShortLink(path: string, isForce = false, shareUrl?: string): Promise<string | null> {
         const endpoint = `/api/share/short_link`;
         try {
-            const body: Record<string, unknown> = {
-                path: path,
+            const body = {
+                path,
                 pathHash: hashContent(path),
                 vault: this.plugin.settings.vault,
-                isForce: isForce,
+                isForce,
+                ...(shareUrl ? { url: shareUrl } : {}),
             };
-            if (shareUrl) {
-                body.url = shareUrl;
-            }
             const { status, json } = await this.request(endpoint, {
                 method: "POST",
                 body: JSON.stringify(body)

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -536,17 +536,21 @@ export class HttpApiService {
     /**
      * 创建或强制重新生成短链接
      */
-    async createShortLink(path: string, isForce = false): Promise<string | null> {
+    async createShortLink(path: string, isForce = false, shareUrl?: string): Promise<string | null> {
         const endpoint = `/api/share/short_link`;
         try {
+            const body: Record<string, unknown> = {
+                path: path,
+                pathHash: hashContent(path),
+                vault: this.plugin.settings.vault,
+                isForce: isForce,
+            };
+            if (shareUrl) {
+                body.url = shareUrl;
+            }
             const { status, json } = await this.request(endpoint, {
                 method: "POST",
-                body: JSON.stringify({
-                    path: path,
-                    pathHash: hashContent(path),
-                    vault: this.plugin.settings.vault,
-                    isForce: isForce
-                })
+                body: JSON.stringify(body)
             });
 
             if (status !== 200 || json.code <= 0) {

--- a/src/views/share-modal.ts
+++ b/src/views/share-modal.ts
@@ -335,7 +335,7 @@ export class ShareModal extends Modal {
             
             refreshBtn.onClick(async () => {
                 refreshBtn.setDisabled(true);
-                const newShortLink = await this.plugin.api.createShortLink(this.path, true);
+                const newShortLink = await this.plugin.api.createShortLink(this.path, true, shareUrl);
                 if (newShortLink) {
                     this.shareData!.shortLink = newShortLink;
                     this.render();
@@ -359,7 +359,7 @@ export class ShareModal extends Modal {
                 .onClick(async () => {
                     this.loading = true;
                     this.render();
-                    const shortLink = await this.plugin.api.createShortLink(this.path);
+                    const shortLink = await this.plugin.api.createShortLink(this.path, false, shareUrl);
                     this.loading = false;
                     if (shortLink) {
                         this.shareData!.shortLink = shortLink;


### PR DESCRIPTION
## 问题描述

使用 sink.cool 短网址服务生成短链接后，短链解析跳转的目标 URL 与实际分享链接不一致，导致短链访问失败。

## 修复方案

- `createShortLink` 增加可选 `shareUrl` 参数，非空时传入请求体的 `url` 字段
- `share-modal` 两处调用均传入当前展示的完整分享链接
- 后端直接使用该 URL 调用 sink.cool，不再重新生成 token，确保短链与分享链接完全一致

## 关联 PR

- 后端：haierkeys/fast-note-sync-service#170
- 前端：haierkeys/fast-note-sync-webgui#8