### PR TITLE
feat: 笔记分享状态指示器（文件管理器 + Notebook Navigator + 状态栏）

### DIFF
--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -292,6 +292,8 @@ const en: Partial<LangMap> = {
   "ui.share.passwordPlaceholder": "Enter password...",
   "ui.share.button_creating": "Creating...",
   "ui.share.viewShare": "View Share",
+  "ui.menu.sharing": "Sharing (${count})",
+  "ui.menu.sharing_desc": "Filter to show only shared notes",
   "ui.common.save": "Save",
   "ui.common.saveSuccess": "Saved successfully",
   "ui.common.noChange": "No changes made",

--- a/src/i18n/locales/ja.ts
+++ b/src/i18n/locales/ja.ts
@@ -292,6 +292,8 @@ const ja: Partial<LangMap> = {
   "ui.share.passwordPlaceholder": "パスワードを入力してください...",
   "ui.share.button_creating": "作成中...",
   "ui.share.viewShare": "シェアを表示",
+  "ui.menu.sharing": "共有中（${count}）",
+  "ui.menu.sharing_desc": "共有中のノートのみ表示",
   "ui.common.save": "保存",
   "ui.common.saveSuccess": "保存しました",
   "ui.common.noChange": "変更はありません",

--- a/src/i18n/locales/ko.ts
+++ b/src/i18n/locales/ko.ts
@@ -292,6 +292,8 @@ const ko: Partial<LangMap> = {
   "ui.share.passwordPlaceholder": "비밀번호를 입력하세요...",
   "ui.share.button_creating": "생성 중...",
   "ui.share.viewShare": "공유 보기",
+  "ui.menu.sharing": "공유 중 (${count})",
+  "ui.menu.sharing_desc": "공유 중인 노트만 표시",
   "ui.common.save": "저장",
   "ui.common.saveSuccess": "저장 성공",
   "ui.common.noChange": "변경 사항이 없습니다",

--- a/src/i18n/locales/zh-cn.ts
+++ b/src/i18n/locales/zh-cn.ts
@@ -292,6 +292,8 @@ const zh_cn: Partial<LangMap> = {
   "ui.share.passwordPlaceholder": "请输入密码...",
   "ui.share.button_creating": "正在开启...",
   "ui.share.viewShare": "预览分享",
+  "ui.menu.sharing": "分享中（${count}）",
+  "ui.menu.sharing_desc": "筛选显示分享中的笔记",
   "ui.common.save": "保存",
   "ui.common.saveSuccess": "保存成功",
   "ui.common.noChange": "未做任何修改",

--- a/src/i18n/locales/zh-tw.ts
+++ b/src/i18n/locales/zh-tw.ts
@@ -292,6 +292,8 @@ const zh_tw: Partial<LangMap> = {
   "ui.share.passwordPlaceholder": "請輸入密碼...",
   "ui.share.button_creating": "正在開啟...",
   "ui.share.viewShare": "預覽分享",
+  "ui.menu.sharing": "分享中（${count}）",
+  "ui.menu.sharing_desc": "篩選顯示分享中的筆記",
   "ui.common.save": "儲存",
   "ui.common.saveSuccess": "儲存成功",
   "ui.common.noChange": "未做任何修改",

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -594,6 +594,45 @@ export class HttpApiService {
     }
 
     /**
+     * 获取当前 vault 所有分享中的笔记路径列表（全量）
+     * Get all actively shared note paths for the current vault (full list)
+     */
+    async getSharePaths(): Promise<string[] | null> {
+        const params = new URLSearchParams({
+            vault: this.plugin.settings.vault
+        });
+        const endpoint = `/api/notes/share-paths?${params.toString()}`;
+        try {
+            const { status, json } = await this.request(endpoint, { method: "GET" });
+            if (status !== 200 || json.code <= 0) return null;
+            return json.data || [];
+        } catch (e) {
+            console.error("getSharePaths error:", e);
+            return null;
+        }
+    }
+
+    /**
+     * 获取当前 vault 自 since 时间戳以来的分享路径变更（增量）
+     * Get share path changes since the given timestamp for the current vault (incremental)
+     */
+    async getShareChanges(since: number): Promise<{ added: string[]; removed: string[]; lastTime: number; fullRefreshRequired: boolean } | null> {
+        const params = new URLSearchParams({
+            vault: this.plugin.settings.vault,
+            since: String(since)
+        });
+        const endpoint = `/api/notes/share-changes?${params.toString()}`;
+        try {
+            const { status, json } = await this.request(endpoint, { method: "GET" });
+            if (status !== 200 || json.code <= 0) return null;
+            return json.data || null;
+        } catch (e) {
+            console.error("getShareChanges error:", e);
+            return null;
+        }
+    }
+
+    /**
      * 获取当前用户信息
      */
     async getUserInfo(): Promise<UserDTO> {

--- a/src/lib/local_storage_manager.ts
+++ b/src/lib/local_storage_manager.ts
@@ -42,7 +42,7 @@ export class LocalStorageManager {
     /**
      * 获取元数据项
      */
-    getMetadata(field: 'lastNoteSyncTime' | 'lastFileSyncTime' | 'lastConfigSyncTime' | 'lastFolderSyncTime' | 'clientName' | 'isInitSync' | 'serverVersion' | 'serverVersionIsNew' | 'serverVersionNewName' | 'serverVersionNewLink' | 'pluginVersionIsNew' | 'pluginVersionNewName' | 'pluginVersionNewLink'): any {
+    getMetadata(field: 'lastNoteSyncTime' | 'lastFileSyncTime' | 'lastConfigSyncTime' | 'lastFolderSyncTime' | 'clientName' | 'isInitSync' | 'serverVersion' | 'serverVersionIsNew' | 'serverVersionNewName' | 'serverVersionNewLink' | 'pluginVersionIsNew' | 'pluginVersionNewName' | 'pluginVersionNewLink' | 'lastShareSyncTime'): any {
         const value = this.read(this.getInternalKey(field));
         if (field.endsWith('Time')) {
             return value ? Number(value) : 0;
@@ -56,7 +56,7 @@ export class LocalStorageManager {
     /**
      * 设置元数据项
      */
-    setMetadata(field: 'lastNoteSyncTime' | 'lastFileSyncTime' | 'lastConfigSyncTime' | 'lastFolderSyncTime' | 'clientName' | 'isInitSync' | 'serverVersion' | 'serverVersionIsNew' | 'serverVersionNewName' | 'serverVersionNewLink' | 'pluginVersionIsNew' | 'pluginVersionNewName' | 'pluginVersionNewLink', value: any): void {
+    setMetadata(field: 'lastNoteSyncTime' | 'lastFileSyncTime' | 'lastConfigSyncTime' | 'lastFolderSyncTime' | 'clientName' | 'isInitSync' | 'serverVersion' | 'serverVersionIsNew' | 'serverVersionNewName' | 'serverVersionNewLink' | 'pluginVersionIsNew' | 'pluginVersionNewName' | 'pluginVersionNewLink' | 'lastShareSyncTime', value: any): void {
         this.write(this.getInternalKey(field), String(value));
     }
 

--- a/src/lib/menu_manager.ts
+++ b/src/lib/menu_manager.ts
@@ -256,6 +256,30 @@ export class MenuManager {
       (item as any).dom.setAttribute("aria-label", $("ui.recycle_bin.title"));
     });
 
+    // 分享中（X）菜单项，仅在有分享笔记时显示
+    // Sharing (X) menu item, only shown when there are shared notes
+    const sharedCount = this.plugin.shareIndicatorManager?.getSharedCount() ?? 0;
+    if (sharedCount > 0) {
+      menu.addSeparator();
+      menu.addItem((item: MenuItem) => {
+        const isActive = this.plugin.shareIndicatorManager?.isFilterActive ?? false;
+        item
+          .setIcon("share-2")
+          .setTitle($("ui.menu.sharing", { count: sharedCount }))
+          .setChecked(isActive)
+          .onClick(async () => {
+            this.plugin.shareIndicatorManager?.toggleFilter();
+            // 激活原生文件浏览器侧边栏（筛选仅作用于原生文件浏览器）
+            // Reveal native file explorer sidebar (filter only applies to native file explorer)
+            const leaves = this.plugin.app.workspace.getLeavesOfType("file-explorer");
+            if (leaves.length > 0) {
+              this.plugin.app.workspace.revealLeaf(leaves[0]);
+            }
+          });
+        (item as any).dom.setAttribute("aria-label", $("ui.menu.sharing_desc"));
+      });
+    }
+
     menu.addSeparator();
     menu.addItem((item: MenuItem) => {
       item
@@ -380,8 +404,7 @@ export class MenuManager {
     if (!this.shareStatusBarItem) return;
     const activeFile = this.plugin.app.workspace.getActiveFile();
     const isShared = activeFile
-      && this.plugin.shareIndicatorManager
-      && this.plugin.settings.sharedPaths?.includes(activeFile.path);
+      && this.plugin.shareIndicatorManager?.hasPath(activeFile.path);
 
     const svg = this.shareStatusBarItem.querySelector("svg");
     if (svg) {

--- a/src/lib/menu_manager.ts
+++ b/src/lib/menu_manager.ts
@@ -66,6 +66,14 @@ export class MenuManager {
       }
     });
 
+    // 监听活动文件切换，更新分享图标颜色
+    // Listen for active file changes to update share icon color
+    this.plugin.registerEvent(
+      this.plugin.app.workspace.on("active-leaf-change", () => {
+        this.updateShareIconColor();
+      })
+    );
+
     // 初始化 同步日志 状态栏入口
     this.logStatusBarItem = this.plugin.addStatusBarItem();
     this.logStatusBarItem.addClass("mod-clickable");
@@ -362,5 +370,22 @@ export class MenuManager {
     }
 
     menu.showAtMouseEvent(event);
+  }
+
+  /**
+   * 根据当前活动笔记的分享状态更新状态栏分享图标颜色
+   * Update status bar share icon color based on active note's share status
+   */
+  updateShareIconColor(): void {
+    if (!this.shareStatusBarItem) return;
+    const activeFile = this.plugin.app.workspace.getActiveFile();
+    const isShared = activeFile
+      && this.plugin.shareIndicatorManager
+      && this.plugin.settings.sharedPaths?.includes(activeFile.path);
+
+    const svg = this.shareStatusBarItem.querySelector("svg");
+    if (svg) {
+      svg.style.color = isShared ? "#4caf50" : "";
+    }
   }
 }

--- a/src/lib/share_indicator_manager.ts
+++ b/src/lib/share_indicator_manager.ts
@@ -2,11 +2,25 @@ import type FastSync from "../main";
 
 // 注入的 <style> 元素 ID / ID of the injected <style> element
 const STYLE_EL_ID = "fns-share-indicator-style";
+// 筛选用的 <style> 元素 ID / ID of the filter <style> element
+const FILTER_STYLE_EL_ID = "fns-share-filter-style";
 
 // Lucide share-2 图标（绿色）SVG 字符串 / Lucide share-2 icon (green) SVG string
 const SVG_STR = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="12" height="12" fill="none" stroke="#4caf50" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="18" cy="5" r="3"/><circle cx="6" cy="12" r="3"/><circle cx="18" cy="19" r="3"/><line x1="8.59" y1="13.51" x2="15.42" y2="17.49"/><line x1="15.41" y1="6.51" x2="8.59" y2="10.49"/></svg>`;
 // 编码为 CSS background-image 可用的 data URI / Encoded as data URI usable in CSS background-image
 const SVG_URI = `data:image/svg+xml,${encodeURIComponent(SVG_STR)}`;
+
+// 分享图标 CSS 属性（所有视图共用）/ Share icon CSS properties (shared across all views)
+const ICON_CSS_PROPS = `content: '';
+  display: inline-block;
+  width: 12px;
+  height: 12px;
+  background-image: url("${SVG_URI}");
+  background-size: contain;
+  background-repeat: no-repeat;
+  margin-right: 4px;
+  vertical-align: middle;
+  opacity: 0.85;`;
 
 // 启动后延迟同步，避免与 Obsidian 启动任务竞争网络资源
 // Delay sync after startup to avoid competing with Obsidian startup tasks for network resources
@@ -21,6 +35,10 @@ export class ShareIndicatorManager {
     private sharedPaths: Set<string> = new Set();
     // 已注入的 <style> 元素引用 / Reference to the injected <style> element
     private styleEl: HTMLStyleElement | null = null;
+    // 筛选用的 <style> 元素引用 / Reference to the filter <style> element
+    private filterStyleEl: HTMLStyleElement | null = null;
+    // 筛选是否激活 / Whether the filter is active
+    private _isFilterActive = false;
     // 网络重连处理器引用（用于 removeEventListener）/ Online handler ref for removeEventListener
     private onlineHandler: (() => void) | null = null;
     // 启动延迟定时器 / Startup delay timer
@@ -88,12 +106,16 @@ export class ShareIndicatorManager {
                     await this._fullRefresh();
                 } else {
                     // 应用增量变更 / Apply delta changes
-                    for (const p of changes.removed) this.sharedPaths.delete(p);
-                    for (const p of changes.added) this.sharedPaths.add(p);
-                    this.plugin.settings.sharedPaths = Array.from(this.sharedPaths);
-                    await this.plugin.saveData(this.plugin.settings);
+                    if (changes.removed.length > 0 || changes.added.length > 0) {
+                        for (const p of changes.removed) this.sharedPaths.delete(p);
+                        for (const p of changes.added) this.sharedPaths.add(p);
+                        this.plugin.settings.sharedPaths = Array.from(this.sharedPaths);
+                        await this.plugin.saveData(this.plugin.settings);
+                        this.regenerateCss();
+                    }
+                    // 无论是否有变更，都更新时间戳（缩小下次增量查询范围）
+                    // Always update timestamp regardless of changes (narrow next incremental query range)
                     this.plugin.localStorageManager?.setMetadata("lastShareSyncTime", changes.lastTime);
-                    this.regenerateCss();
                 }
             } else {
                 // 首次同步，全量拉取 / First sync: full fetch
@@ -144,6 +166,138 @@ export class ShareIndicatorManager {
         this.regenerateCss();
         // 同步更新状态栏分享图标颜色 / Sync status bar share icon color
         this.plugin.menuManager?.updateShareIconColor();
+        // 如果筛选激活且没有分享路径了，自动关闭筛选
+        // If filter is active and no shared paths remain, auto-deactivate filter
+        if (this._isFilterActive && this.sharedPaths.size === 0) {
+            this._isFilterActive = false;
+            this.removeFilterCss();
+        } else if (this._isFilterActive) {
+            // 更新筛选 CSS 以反映最新的分享列表
+            // Update filter CSS to reflect the latest shared paths
+            this.injectFilterCss();
+        }
+    }
+
+    /**
+     * 获取当前分享中的路径数量
+     * Get the count of currently shared paths
+     */
+    getSharedCount(): number {
+        return this.sharedPaths.size;
+    }
+
+    /**
+     * 判断指定路径是否正在分享中（O(1) Set 查找）
+     * Check if a given path is currently shared (O(1) Set lookup)
+     */
+    hasPath(path: string): boolean {
+        return this.sharedPaths.has(path);
+    }
+
+    /**
+     * 获取筛选是否激活
+     * Get whether the filter is active
+     */
+    get isFilterActive(): boolean {
+        return this._isFilterActive;
+    }
+
+    /**
+     * 切换筛选状态：激活时注入筛选 CSS 并展开相关文件夹，取消时移除
+     * Toggle filter state: inject filter CSS and expand folders when activating, remove when deactivating
+     */
+    toggleFilter(): void {
+        this._isFilterActive = !this._isFilterActive;
+        if (this._isFilterActive) {
+            const ancestors = this.getAllAncestorFolders();
+            this.injectFilterCss(ancestors);
+            this.expandSharedFolders(ancestors);
+        } else {
+            this.removeFilterCss();
+        }
+    }
+
+    /**
+     * 收集所有分享路径的祖先文件夹路径（去重）
+     * Collect all ancestor folder paths for shared paths (deduplicated)
+     */
+    private getAllAncestorFolders(): Set<string> {
+        const folders = new Set<string>();
+        for (const path of this.sharedPaths) {
+            const parts = path.split("/");
+            // 跳过最后一段（文件名），逐级构建祖先路径
+            // Skip last segment (filename), build ancestor paths level by level
+            for (let i = 1; i < parts.length; i++) {
+                folders.add(parts.slice(0, i).join("/"));
+            }
+        }
+        return folders;
+    }
+
+    /**
+     * 注入筛选 CSS，隐藏原生文件浏览器中非分享文件和空文件夹
+     * Inject filter CSS to hide non-shared files and empty folders in native file explorer
+     */
+    private injectFilterCss(ancestors?: Set<string>): void {
+        document.getElementById(FILTER_STYLE_EL_ID)?.remove();
+        this.filterStyleEl = null;
+
+        if (this.sharedPaths.size === 0) return;
+
+        const rules: string[] = [];
+
+        // 原生文件浏览器：隐藏所有文件项
+        // Native file explorer: hide all file items
+        rules.push(`.nav-file { display: none !important; }`);
+
+        // 隐藏不包含分享文件的文件夹（排除根文件夹）
+        // Hide folders that don't contain shared files (exclude root folder)
+        rules.push(`.nav-folder:not(.mod-root) { display: none !important; }`);
+
+        for (const path of this.sharedPaths) {
+            // 原生文件浏览器：显示分享的文件
+            // Native file explorer: show shared files
+            rules.push(`.nav-file:has(.nav-file-title[data-path="${path}"]) { display: block !important; }`);
+        }
+
+        // 显示所有祖先文件夹（包含分享文件的直接父级及更上层）
+        // Show all ancestor folders (direct parents and higher ancestors of shared files)
+        for (const folderPath of (ancestors ?? this.getAllAncestorFolders())) {
+            rules.push(`.nav-folder:has(> .nav-folder-title[data-path="${folderPath}"]) { display: block !important; }`);
+        }
+
+        const el = document.createElement("style");
+        el.id = FILTER_STYLE_EL_ID;
+        el.textContent = rules.join("\n");
+        document.head.appendChild(el);
+        this.filterStyleEl = el;
+    }
+
+    /**
+     * 移除筛选 CSS，恢复所有文件显示
+     * Remove filter CSS to restore all files display
+     */
+    private removeFilterCss(): void {
+        document.getElementById(FILTER_STYLE_EL_ID)?.remove();
+        this.filterStyleEl = null;
+    }
+
+    /**
+     * 展开包含分享文件的文件夹（原生文件浏览器）
+     * Expand folders that contain shared files (native file explorer)
+     */
+    private expandSharedFolders(ancestors?: Set<string>): void {
+        for (const folderPath of (ancestors ?? this.getAllAncestorFolders())) {
+            // 查找折叠状态的文件夹并展开
+            // Find collapsed folders and expand them
+            const folderEl = document.querySelector(
+                `.nav-folder:has(> .nav-folder-title[data-path="${folderPath}"]).is-collapsed`
+            );
+            if (folderEl) {
+                const titleEl = folderEl.querySelector(".nav-folder-title") as HTMLElement | null;
+                titleEl?.click();
+            }
+        }
     }
 
     /**
@@ -161,6 +315,10 @@ export class ShareIndicatorManager {
         }
         this.styleEl?.remove();
         this.styleEl = null;
+        // 清理筛选样式 / Clean up filter style
+        this.filterStyleEl?.remove();
+        this.filterStyleEl = null;
+        this._isFilterActive = false;
     }
 
     /**
@@ -176,50 +334,14 @@ export class ShareIndicatorManager {
 
         const rules: string[] = [];
         for (const path of this.sharedPaths) {
-            // Notebook Navigator 导航树视图: 图标在标题左侧 via ::before 伪元素
-            // Notebook Navigator nav tree view: icon left of title via ::before pseudo-element
-            rules.push(`[data-drag-path="${path}"] .nn-navitem-name::before {
-  content: '';
-  display: inline-block;
-  width: 12px;
-  height: 12px;
-  background-image: url("${SVG_URI}");
-  background-size: contain;
-  background-repeat: no-repeat;
-  margin-right: 4px;
-  vertical-align: middle;
-  opacity: 0.85;
-}`);
-
-            // Notebook Navigator 笔记列表视图: 图标在标题左侧 via ::before 伪元素
-            // Notebook Navigator file list view: icon left of title via ::before pseudo-element
-            rules.push(`[data-drag-path="${path}"] .nn-file-name::before {
-  content: '';
-  display: inline-block;
-  width: 12px;
-  height: 12px;
-  background-image: url("${SVG_URI}");
-  background-size: contain;
-  background-repeat: no-repeat;
-  margin-right: 4px;
-  vertical-align: middle;
-  opacity: 0.85;
-}`);
-
-            // 原生文件浏览器: 图标在文件名左侧 via ::before 伪元素
-            // Native file explorer: icon left of filename via ::before pseudo-element
-            rules.push(`.nav-file-title[data-path="${path}"] .nav-file-title-content::before {
-  content: '';
-  display: inline-block;
-  width: 12px;
-  height: 12px;
-  background-image: url("${SVG_URI}");
-  background-size: contain;
-  background-repeat: no-repeat;
-  margin-right: 4px;
-  vertical-align: middle;
-  opacity: 0.85;
-}`);
+            // 三种视图共用相同图标样式，仅选择器不同
+            // All three views share the same icon style, only selectors differ
+            const selectors = [
+                `[data-drag-path="${path}"] .nn-navitem-name::before`,  // Notebook Navigator 导航树 / nav tree
+                `[data-drag-path="${path}"] .nn-file-name::before`,     // Notebook Navigator 笔记列表 / file list
+                `.nav-file-title[data-path="${path}"] .nav-file-title-content::before`, // 原生文件浏览器 / native explorer
+            ];
+            rules.push(`${selectors.join(",\n")} {\n${ICON_CSS_PROPS}\n}`);
         }
 
         const el = document.createElement("style");

--- a/src/lib/share_indicator_manager.ts
+++ b/src/lib/share_indicator_manager.ts
@@ -206,9 +206,9 @@ export class ShareIndicatorManager {
   opacity: 0.85;
 }`);
 
-            // 原生文件浏览器: 图标在文件名右侧 via ::after 伪元素
-            // Native file explorer: icon right of filename via ::after pseudo-element
-            rules.push(`.nav-file-title[data-path="${path}"]::after {
+            // 原生文件浏览器: 图标在文件名左侧 via ::before 伪元素
+            // Native file explorer: icon left of filename via ::before pseudo-element
+            rules.push(`.nav-file-title[data-path="${path}"] .nav-file-title-content::before {
   content: '';
   display: inline-block;
   width: 12px;
@@ -216,7 +216,7 @@ export class ShareIndicatorManager {
   background-image: url("${SVG_URI}");
   background-size: contain;
   background-repeat: no-repeat;
-  margin-left: 4px;
+  margin-right: 4px;
   vertical-align: middle;
   opacity: 0.85;
 }`);

--- a/src/lib/share_indicator_manager.ts
+++ b/src/lib/share_indicator_manager.ts
@@ -129,6 +129,8 @@ export class ShareIndicatorManager {
         this.plugin.settings.sharedPaths = Array.from(this.sharedPaths);
         await this.plugin.saveData(this.plugin.settings);
         this.regenerateCss();
+        // 同步更新状态栏分享图标颜色 / Sync status bar share icon color
+        this.plugin.menuManager?.updateShareIconColor();
     }
 
     /**
@@ -140,6 +142,8 @@ export class ShareIndicatorManager {
         this.plugin.settings.sharedPaths = Array.from(this.sharedPaths);
         await this.plugin.saveData(this.plugin.settings);
         this.regenerateCss();
+        // 同步更新状态栏分享图标颜色 / Sync status bar share icon color
+        this.plugin.menuManager?.updateShareIconColor();
     }
 
     /**
@@ -172,9 +176,24 @@ export class ShareIndicatorManager {
 
         const rules: string[] = [];
         for (const path of this.sharedPaths) {
-            // Notebook Navigator: 图标在标题左侧 via ::before 伪元素
-            // Notebook Navigator: icon left of title via ::before pseudo-element
+            // Notebook Navigator 导航树视图: 图标在标题左侧 via ::before 伪元素
+            // Notebook Navigator nav tree view: icon left of title via ::before pseudo-element
             rules.push(`[data-drag-path="${path}"] .nn-navitem-name::before {
+  content: '';
+  display: inline-block;
+  width: 12px;
+  height: 12px;
+  background-image: url("${SVG_URI}");
+  background-size: contain;
+  background-repeat: no-repeat;
+  margin-right: 4px;
+  vertical-align: middle;
+  opacity: 0.85;
+}`);
+
+            // Notebook Navigator 笔记列表视图: 图标在标题左侧 via ::before 伪元素
+            // Notebook Navigator file list view: icon left of title via ::before pseudo-element
+            rules.push(`[data-drag-path="${path}"] .nn-file-name::before {
   content: '';
   display: inline-block;
   width: 12px;

--- a/src/lib/share_indicator_manager.ts
+++ b/src/lib/share_indicator_manager.ts
@@ -1,0 +1,194 @@
+import type FastSync from "../main";
+
+// 注入的 <style> 元素 ID / ID of the injected <style> element
+const STYLE_EL_ID = "fns-share-indicator-style";
+
+// Lucide share-2 图标（绿色）SVG 字符串 / Lucide share-2 icon (green) SVG string
+const SVG_STR = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="12" height="12" fill="none" stroke="#4caf50" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="18" cy="5" r="3"/><circle cx="6" cy="12" r="3"/><circle cx="18" cy="19" r="3"/><line x1="8.59" y1="13.51" x2="15.42" y2="17.49"/><line x1="15.41" y1="6.51" x2="8.59" y2="10.49"/></svg>`;
+// 编码为 CSS background-image 可用的 data URI / Encoded as data URI usable in CSS background-image
+const SVG_URI = `data:image/svg+xml,${encodeURIComponent(SVG_STR)}`;
+
+// 启动后延迟同步，避免与 Obsidian 启动任务竞争网络资源
+// Delay sync after startup to avoid competing with Obsidian startup tasks for network resources
+const STARTUP_DELAY_MS = 5000;
+
+// 重连后延迟，等待网络连接稳定
+// Delay after reconnect to wait for network connection to stabilize
+const RECONNECT_DELAY_MS = 2000;
+
+export class ShareIndicatorManager {
+    // 内存中的分享路径集合 / In-memory set of shared paths
+    private sharedPaths: Set<string> = new Set();
+    // 已注入的 <style> 元素引用 / Reference to the injected <style> element
+    private styleEl: HTMLStyleElement | null = null;
+    // 网络重连处理器引用（用于 removeEventListener）/ Online handler ref for removeEventListener
+    private onlineHandler: (() => void) | null = null;
+    // 启动延迟定时器 / Startup delay timer
+    private startupTimer: ReturnType<typeof setTimeout> | null = null;
+
+    constructor(private plugin: FastSync) {}
+
+    /**
+     * 初始化：从 data.json 加载本地缓存立即注入 CSS，然后延迟从服务器同步
+     * Initialize: load local cache from data.json and inject CSS immediately, then sync from server after delay
+     */
+    async initialize(): Promise<void> {
+        // 从持久化设置中恢复缓存，立即注入 CSS（不等待网络）
+        // Restore cache from persisted settings, inject CSS immediately (no network wait)
+        const saved = this.plugin.settings.sharedPaths ?? [];
+        this.sharedPaths = new Set(saved);
+        this.regenerateCss();
+
+        // 注册设备上线事件：重连后增量同步，恢复离线期间的变更
+        // Register online event: incremental sync on reconnect to recover offline changes
+        this.onlineHandler = () => {
+            setTimeout(() => this.syncWithServer().catch(() => {}), RECONNECT_DELAY_MS);
+        };
+        window.addEventListener("online", this.onlineHandler);
+
+        // 启动后延迟 5s 再同步，避免与 Obsidian 其他启动任务竞争网络资源
+        // Delay sync by 5s after startup to avoid competing with other Obsidian startup tasks
+        this.startupTimer = setTimeout(() => {
+            this.syncWithServer().catch(() => {});
+        }, STARTUP_DELAY_MS);
+    }
+
+    /**
+     * 增量优先的服务端同步：有 lastShareSyncTime 时走增量，否则全量拉取
+     * Delta-first server sync: use incremental if lastShareSyncTime exists, else full refresh
+     */
+    async syncWithServer(): Promise<void> {
+        if (!this.plugin.settings.api || !this.plugin.settings.apiToken) return;
+
+        const lastSyncTime = Number(
+            this.plugin.localStorageManager?.getMetadata("lastShareSyncTime") ?? 0
+        );
+
+        if (lastSyncTime > 0) {
+            // 增量同步 / Incremental sync
+            const changes = await this.plugin.api.getShareChanges(lastSyncTime);
+            if (changes === null) return; // 网络错误，静默失败 / Network error, fail silently
+
+            if (changes.fullRefreshRequired) {
+                await this._fullRefresh();
+            } else {
+                // 应用增量变更 / Apply delta changes
+                for (const p of changes.removed) this.sharedPaths.delete(p);
+                for (const p of changes.added) this.sharedPaths.add(p);
+                this.plugin.settings.sharedPaths = Array.from(this.sharedPaths);
+                await this.plugin.saveData(this.plugin.settings);
+                this.plugin.localStorageManager?.setMetadata("lastShareSyncTime", changes.lastTime);
+                this.regenerateCss();
+            }
+        } else {
+            // 首次同步，全量拉取 / First sync: full fetch
+            await this._fullRefresh();
+        }
+    }
+
+    /**
+     * 全量拉取并覆盖本地缓存
+     * Full fetch: overwrite local cache with server's complete active share list
+     */
+    private async _fullRefresh(): Promise<void> {
+        const paths = await this.plugin.api.getSharePaths();
+        if (paths === null) return; // 网络错误，静默失败 / Network error, fail silently
+        this.sharedPaths = new Set(paths);
+        this.plugin.settings.sharedPaths = paths;
+        await this.plugin.saveData(this.plugin.settings);
+        // 记录全量拉取完成的时间戳，供后续增量请求使用
+        // Record timestamp of full fetch completion for future delta requests
+        this.plugin.localStorageManager?.setMetadata("lastShareSyncTime", Date.now());
+        this.regenerateCss();
+    }
+
+    /**
+     * 添加分享路径、持久化并更新 CSS（用户在本设备创建分享时调用）
+     * Add a shared path, persist, and update CSS (called when user creates a share on this device)
+     */
+    async addSharedPath(path: string): Promise<void> {
+        this.sharedPaths.add(path);
+        this.plugin.settings.sharedPaths = Array.from(this.sharedPaths);
+        await this.plugin.saveData(this.plugin.settings);
+        this.regenerateCss();
+    }
+
+    /**
+     * 移除分享路径、持久化并更新 CSS（用户在本设备取消分享时调用）
+     * Remove a shared path, persist, and update CSS (called when user cancels a share on this device)
+     */
+    async removeSharedPath(path: string): Promise<void> {
+        this.sharedPaths.delete(path);
+        this.plugin.settings.sharedPaths = Array.from(this.sharedPaths);
+        await this.plugin.saveData(this.plugin.settings);
+        this.regenerateCss();
+    }
+
+    /**
+     * 移除注入的 <style> 元素并清理事件监听（插件卸载时调用）
+     * Remove injected <style> and clean up event listeners (called on plugin unload)
+     */
+    unload(): void {
+        if (this.startupTimer !== null) {
+            clearTimeout(this.startupTimer);
+            this.startupTimer = null;
+        }
+        if (this.onlineHandler) {
+            window.removeEventListener("online", this.onlineHandler);
+            this.onlineHandler = null;
+        }
+        this.styleEl?.remove();
+        this.styleEl = null;
+    }
+
+    /**
+     * 重新生成 CSS 规则并注入到 document.head
+     * Regenerate CSS rules and inject into document.head
+     */
+    private regenerateCss(): void {
+        // 移除旧的 style 元素 / Remove old style element
+        document.getElementById(STYLE_EL_ID)?.remove();
+        this.styleEl = null;
+
+        if (this.sharedPaths.size === 0) return;
+
+        const rules: string[] = [];
+        for (const path of this.sharedPaths) {
+            // Notebook Navigator: 图标在标题左侧 via ::before 伪元素
+            // Notebook Navigator: icon left of title via ::before pseudo-element
+            rules.push(`[data-drag-path="${path}"] .nn-navitem-name::before {
+  content: '';
+  display: inline-block;
+  width: 12px;
+  height: 12px;
+  background-image: url("${SVG_URI}");
+  background-size: contain;
+  background-repeat: no-repeat;
+  margin-right: 4px;
+  vertical-align: middle;
+  opacity: 0.85;
+}`);
+
+            // 原生文件浏览器: 图标在文件名右侧 via ::after 伪元素
+            // Native file explorer: icon right of filename via ::after pseudo-element
+            rules.push(`.nav-file-title[data-path="${path}"]::after {
+  content: '';
+  display: inline-block;
+  width: 12px;
+  height: 12px;
+  background-image: url("${SVG_URI}");
+  background-size: contain;
+  background-repeat: no-repeat;
+  margin-left: 4px;
+  vertical-align: middle;
+  opacity: 0.85;
+}`);
+        }
+
+        const el = document.createElement("style");
+        el.id = STYLE_EL_ID;
+        el.textContent = rules.join("\n");
+        document.head.appendChild(el);
+        this.styleEl = el;
+    }
+}

--- a/src/lib/share_indicator_manager.ts
+++ b/src/lib/share_indicator_manager.ts
@@ -25,6 +25,8 @@ export class ShareIndicatorManager {
     private onlineHandler: (() => void) | null = null;
     // 启动延迟定时器 / Startup delay timer
     private startupTimer: ReturnType<typeof setTimeout> | null = null;
+    // 并发同步守卫，防止多个 syncWithServer 同时执行 / Concurrent sync guard to prevent multiple syncWithServer calls running simultaneously
+    private isSyncing = false;
 
     constructor(private plugin: FastSync) {}
 
@@ -33,6 +35,16 @@ export class ShareIndicatorManager {
      * Initialize: load local cache from data.json and inject CSS immediately, then sync from server after delay
      */
     async initialize(): Promise<void> {
+        // 防止重复调用导致监听器和定时器泄漏 / Prevent listener and timer leaks on re-initialization
+        if (this.startupTimer !== null) {
+            clearTimeout(this.startupTimer);
+            this.startupTimer = null;
+        }
+        if (this.onlineHandler) {
+            window.removeEventListener('online', this.onlineHandler);
+            this.onlineHandler = null;
+        }
+
         // 从持久化设置中恢复缓存，立即注入 CSS（不等待网络）
         // Restore cache from persisted settings, inject CSS immediately (no network wait)
         const saved = this.plugin.settings.sharedPaths ?? [];
@@ -58,31 +70,37 @@ export class ShareIndicatorManager {
      * Delta-first server sync: use incremental if lastShareSyncTime exists, else full refresh
      */
     async syncWithServer(): Promise<void> {
-        if (!this.plugin.settings.api || !this.plugin.settings.apiToken) return;
+        if (this.isSyncing) return;
+        this.isSyncing = true;
+        try {
+            if (!this.plugin.settings.api || !this.plugin.settings.apiToken) return;
 
-        const lastSyncTime = Number(
-            this.plugin.localStorageManager?.getMetadata("lastShareSyncTime") ?? 0
-        );
+            const lastSyncTime = Number(
+                this.plugin.localStorageManager?.getMetadata("lastShareSyncTime") ?? 0
+            );
 
-        if (lastSyncTime > 0) {
-            // 增量同步 / Incremental sync
-            const changes = await this.plugin.api.getShareChanges(lastSyncTime);
-            if (changes === null) return; // 网络错误，静默失败 / Network error, fail silently
+            if (lastSyncTime > 0) {
+                // 增量同步 / Incremental sync
+                const changes = await this.plugin.api.getShareChanges(lastSyncTime);
+                if (changes === null) return; // 网络错误，静默失败 / Network error, fail silently
 
-            if (changes.fullRefreshRequired) {
-                await this._fullRefresh();
+                if (changes.fullRefreshRequired) {
+                    await this._fullRefresh();
+                } else {
+                    // 应用增量变更 / Apply delta changes
+                    for (const p of changes.removed) this.sharedPaths.delete(p);
+                    for (const p of changes.added) this.sharedPaths.add(p);
+                    this.plugin.settings.sharedPaths = Array.from(this.sharedPaths);
+                    await this.plugin.saveData(this.plugin.settings);
+                    this.plugin.localStorageManager?.setMetadata("lastShareSyncTime", changes.lastTime);
+                    this.regenerateCss();
+                }
             } else {
-                // 应用增量变更 / Apply delta changes
-                for (const p of changes.removed) this.sharedPaths.delete(p);
-                for (const p of changes.added) this.sharedPaths.add(p);
-                this.plugin.settings.sharedPaths = Array.from(this.sharedPaths);
-                await this.plugin.saveData(this.plugin.settings);
-                this.plugin.localStorageManager?.setMetadata("lastShareSyncTime", changes.lastTime);
-                this.regenerateCss();
+                // 首次同步，全量拉取 / First sync: full fetch
+                await this._fullRefresh();
             }
-        } else {
-            // 首次同步，全量拉取 / First sync: full fetch
-            await this._fullRefresh();
+        } finally {
+            this.isSyncing = false;
         }
     }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -18,7 +18,8 @@ import { MenuManager } from "./lib/menu_manager";
 import { LockManager } from "./lib/lock_manager";
 import { handleSync } from "./lib/operator";
 import { HttpApiService } from "./lib/api";
-import { $ } from "./i18n/lang";
+import { $ } from "./i18n/lang"
+import { ShareIndicatorManager } from "./lib/share_indicator_manager";
 
 
 export default class FastSync extends Plugin {
@@ -33,6 +34,7 @@ export default class FastSync extends Plugin {
   lockManager: LockManager // 锁管理器
   eventManager: EventManager // 事件管理器
   menuManager: MenuManager // 菜单管理器
+  shareIndicatorManager: ShareIndicatorManager // 分享指示器管理器 / Share indicator manager
   fileHashManager: FileHashManager // 文件哈希管理器
   configHashManager: ConfigHashManager // 配置哈希管理器
   localStorageManager: LocalStorageManager // 本地存储管理器
@@ -229,6 +231,10 @@ export default class FastSync extends Plugin {
       this.menuManager = new MenuManager(this)
       this.menuManager.init()
 
+      // 初始化分享指示器管理器 / Initialize share indicator manager
+      this.shareIndicatorManager = new ShareIndicatorManager(this)
+      this.shareIndicatorManager.initialize()
+
       // 4. 初始化功能管理器 (实例化)
       this.fileCloudPreview = new FileCloudPreview(this)
       this.fileHashManager = new FileHashManager(this)
@@ -259,6 +265,7 @@ export default class FastSync extends Plugin {
 
   onunload() {
     this.localStorageManager?.stopWatch()
+    this.shareIndicatorManager?.unload()
     // 取消注册文件事件
     this.refreshRuntime(false)
     this.updateStatusBar("")

--- a/src/setting.tsx
+++ b/src/setting.tsx
@@ -66,6 +66,9 @@ export interface PluginSettings {
   networkLibrary: 'fetch' | 'requestUrl'
   /** 最小化自动暂停同步 */
   autoPauseMinimized: boolean
+  /** 分享中的笔记路径缓存（vault-relative 格式）
+   * Cache of actively shared note paths (vault-relative format) */
+  sharedPaths: string[]
 }
 
 /**
@@ -109,6 +112,7 @@ export const DEFAULT_SETTINGS: PluginSettings = {
   configSyncOtherDirs: "",
   networkLibrary: "requestUrl",
   autoPauseMinimized: false,
+  sharedPaths: [],
 }
 
 

--- a/src/views/share-modal.ts
+++ b/src/views/share-modal.ts
@@ -98,6 +98,8 @@ export class ShareModal extends Modal {
                 if (res) {
                     this.shareData = res;
                     new Notice($("ui.share.success"));
+                    // 更新分享指示器缓存 / Update share indicator cache
+                    this.plugin.shareIndicatorManager?.addSharedPath(this.path);
                 }
                 this.render();
             });
@@ -422,6 +424,8 @@ export class ShareModal extends Modal {
                 this.isPasswordVisible = false;
                 this.isPasswordDirty = false;
                 new Notice($("ui.share.cancel_success"));
+                // 更新分享指示器缓存 / Update share indicator cache
+                this.plugin.shareIndicatorManager?.removeSharedPath(this.path);
             }
             this.render();
         });


### PR DESCRIPTION
## Summary

在 Obsidian 的文件列表中为分享中的笔记显示绿色分享图标，支持三种视图：

- **原生文件管理器**：分享图标显示在文件名旁
- **Notebook Navigator 导航树 + 笔记列表**：分享图标显示在标题旁
- **状态栏**：当前打开的笔记处于分享中时，右下角分享图标变为绿色

### 实现方式

- **CSS 注入**：通过 `<style>` 元素注入 `::before` / `::after` 伪元素，无需修改 Notebook Navigator 源码，虚拟列表兼容
- **增量同步**：启动时从 `data.json` 恢复缓存立即显示，5s 后通过 `GET /api/notes/share-changes` 增量同步；设备重新上线时自动同步

### 截图

#### 原生文件管理器
<img width="204" height="332" alt="image" src="https://github.com/user-attachments/assets/dae9da7e-e0e2-4adc-be36-b1681fc86534" />


#### Notebook Navigator
<img width="560" height="483" alt="image" src="https://github.com/user-attachments/assets/99b6ee7c-5cc7-4b85-acc5-80eee1934918" />


#### 状态栏分享图标
<img width="144" height="30" alt="image" src="https://github.com/user-attachments/assets/9457e2a0-55ad-4a3b-b6e8-c4b20c8c3b5c" />


## 服务端依赖
> [!IMPORTANT]
>  ⚠️ 此功能依赖服务端新增的 `GET /api/notes/share-changes` 接口，对应 PR：haierkeys/fast-note-sync-service#190


## 新增/修改文件

| 文件 | 变更 |
|------|------|
| `src/lib/share_indicator_manager.ts` | **新增** — CSS 注入、增量同步、重连恢复 |
| `src/lib/api.ts` | 新增 `getSharePaths()` / `getShareChanges()` 方法 |
| `src/lib/local_storage_manager.ts` | 新增 `lastShareSyncTime` 元数据字段 |
| `src/lib/menu_manager.ts` | 新增 `updateShareIconColor()` + 监听活动文件切换 |
| `src/setting.tsx` | 新增 `sharedPaths: string[]` 持久化字段 |
| `src/main.ts` | 集成 `ShareIndicatorManager` 生命周期 |
| `src/views/share-modal.ts` | 创建/取消分享后更新指示器缓存 |

## Test plan

- [ ] 分享一个笔记 → 确认绿色图标出现在原生文件管理器和 Notebook Navigator 中
- [ ] 取消分享 → 确认图标消失
- [ ] 重启 Obsidian → 约 5s 后图标重新出现
- [ ] 切换到分享中的笔记 → 状态栏分享图标变绿；切换到未分享笔记 → 恢复默认色
- [ ] 在 Notebook Navigator 中滚动已分享笔记出视野再滚回 → 图标正常显示

🤖 Generated with [Claude Code](https://claude.com/claude-code)