### PR TITLE
fix: 修复配置同步卡在 25% 的问题

### DIFF
--- a/src/lib/operator.ts
+++ b/src/lib/operator.ts
@@ -288,6 +288,19 @@ export const handleSync = async function (plugin: FastSync, isLoadLastTime: bool
   const shouldSyncNotes = syncMode === "auto" || syncMode === "note";
   const shouldSyncConfigs = syncMode === "auto" || syncMode === "config";
 
+  // 预先标记未参与本次同步的模块为已结束，避免 checkSyncCompletion 永远等待它们
+  // Pre-mark modules not participating in this sync as ended to prevent checkSyncCompletion from waiting forever
+  if (!(plugin.settings.syncEnabled && shouldSyncNotes)) {
+    plugin.noteSyncEnd = true;
+    plugin.fileSyncEnd = true;
+    plugin.folderSyncEnd = true;
+  } else if (plugin.settings.cloudPreviewEnabled && !plugin.settings.cloudPreviewTypeRestricted) {
+    plugin.fileSyncEnd = true;
+  }
+  if (!(plugin.settings.configSyncEnabled && shouldSyncConfigs)) {
+    plugin.configSyncEnd = true;
+  }
+
   let expectedCount = 0;
   if (plugin.settings.syncEnabled && shouldSyncNotes) {
     expectedCount += 1; // NoteSync


### PR DESCRIPTION
## Summary
- 修复当触发 config-only 同步（如清理远端配置、首次开启配置自动同步）时，同步进度卡在 25% 且永远不会结束的问题
- 根因：`checkSyncCompletion()` 按 settings 中启用的全部模块（note/file/config/folder）计算进度，但 config-only 同步只发送 `SettingSync` 请求，note/file/folder 模块永远收不到 SyncEnd 消息，导致进度 = 1/4 = 25%，且 `enableWatch()` 永远不被调用，阻塞后续所有同步
- 修复：在 `handleSync()` 中为不参与本次同步的模块预设 `*SyncEnd = true`，使 `checkSyncCompletion` 不再等待这些模块的 End 消息

## 影响场景
- 点击"清理远端配置"后同步卡 25%
- 首次开启"配置自动同步"后卡 25%
- 先关闭再开启配置自动同步后卡 25%

## Test plan
- [ ] 笔记同步已开启 → 开启配置自动同步 → 同步正常完成（不卡 25%）
- [ ] 点击"清理远端配置" → 后续同步正常完成
- [ ] 关闭配置自动同步 → 清理远端配置 → 重新开启 → 同步正常
- [ ] 全量同步（syncMode=auto）行为不受影响

🤖 Generated with [Claude Code](https://claude.com/claude-code)