### PR TITLE
修复分享状态同步问题，简化分享状态同步，移除上次新增的分享更新增量接口

### DIFF
--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -613,26 +613,6 @@ export class HttpApiService {
     }
 
     /**
-     * 获取当前 vault 自 since 时间戳以来的分享路径变更（增量）
-     * Get share path changes since the given timestamp for the current vault (incremental)
-     */
-    async getShareChanges(since: number): Promise<{ added: string[]; removed: string[]; lastTime: number; fullRefreshRequired: boolean } | null> {
-        const params = new URLSearchParams({
-            vault: this.plugin.settings.vault,
-            since: String(since)
-        });
-        const endpoint = `/api/notes/share-changes?${params.toString()}`;
-        try {
-            const { status, json } = await this.request(endpoint, { method: "GET" });
-            if (status !== 200 || json.code <= 0) return null;
-            return json.data || null;
-        } catch (e) {
-            console.error("getShareChanges error:", e);
-            return null;
-        }
-    }
-
-    /**
      * 获取当前用户信息
      */
     async getUserInfo(): Promise<UserDTO> {

--- a/src/lib/events_manager.ts
+++ b/src/lib/events_manager.ts
@@ -99,6 +99,9 @@ export class EventManager {
         // 如果未开启自动暂停，确保恢复时监听也是开启的（增强鲁棒性）
         this.plugin.enableWatch()
       }
+      // 恢复前台时刷新分享状态（覆盖短暂后台期间其他设备变更分享的场景）
+      // Refresh share state on foreground resume (covers share changes by other devices during brief background)
+      this.plugin.shareIndicatorManager?.syncWithServer()
     }
   }
 

--- a/src/lib/local_storage_manager.ts
+++ b/src/lib/local_storage_manager.ts
@@ -42,7 +42,7 @@ export class LocalStorageManager {
     /**
      * 获取元数据项
      */
-    getMetadata(field: 'lastNoteSyncTime' | 'lastFileSyncTime' | 'lastConfigSyncTime' | 'lastFolderSyncTime' | 'clientName' | 'isInitSync' | 'serverVersion' | 'serverVersionIsNew' | 'serverVersionNewName' | 'serverVersionNewLink' | 'pluginVersionIsNew' | 'pluginVersionNewName' | 'pluginVersionNewLink' | 'lastShareSyncTime'): any {
+    getMetadata(field: 'lastNoteSyncTime' | 'lastFileSyncTime' | 'lastConfigSyncTime' | 'lastFolderSyncTime' | 'clientName' | 'isInitSync' | 'serverVersion' | 'serverVersionIsNew' | 'serverVersionNewName' | 'serverVersionNewLink' | 'pluginVersionIsNew' | 'pluginVersionNewName' | 'pluginVersionNewLink'): any {
         const value = this.read(this.getInternalKey(field));
         if (field.endsWith('Time')) {
             return value ? Number(value) : 0;
@@ -56,7 +56,7 @@ export class LocalStorageManager {
     /**
      * 设置元数据项
      */
-    setMetadata(field: 'lastNoteSyncTime' | 'lastFileSyncTime' | 'lastConfigSyncTime' | 'lastFolderSyncTime' | 'clientName' | 'isInitSync' | 'serverVersion' | 'serverVersionIsNew' | 'serverVersionNewName' | 'serverVersionNewLink' | 'pluginVersionIsNew' | 'pluginVersionNewName' | 'pluginVersionNewLink' | 'lastShareSyncTime', value: any): void {
+    setMetadata(field: 'lastNoteSyncTime' | 'lastFileSyncTime' | 'lastConfigSyncTime' | 'lastFolderSyncTime' | 'clientName' | 'isInitSync' | 'serverVersion' | 'serverVersionIsNew' | 'serverVersionNewName' | 'serverVersionNewLink' | 'pluginVersionIsNew' | 'pluginVersionNewName' | 'pluginVersionNewLink', value: any): void {
         this.write(this.getInternalKey(field), String(value));
     }
 

--- a/src/lib/operator.ts
+++ b/src/lib/operator.ts
@@ -160,6 +160,10 @@ export function checkSyncCompletion(plugin: FastSync, intervalId?: ReturnType<ty
       checkAndUploadAttachments(plugin);
     }
 
+    // 同步完成后刷新分享指示器状态
+    // Refresh share indicator state after sync completion
+    plugin.shareIndicatorManager?.syncWithServer();
+
     setTimeout(() => plugin.updateStatusBar(""), 3000);
   } else {
     // --- 强制完成逻辑与 90% 补偿 ---
@@ -219,7 +223,17 @@ export const receiveOperators: Map<string, ReceiveOperator> = new Map([
   ["FolderSyncDelete", receiveFolderSyncDelete],
   ["FolderSyncRename", receiveFolderSyncRename],
   ["FolderSyncEnd", (data, plugin) => receiveSyncEndWrapper(data, plugin, "folder")],
+  ["ShareSyncRefresh", receiveShareSyncRefresh],
 ]);
+
+/**
+ * 收到分享状态变更通知，全量刷新分享路径
+ * Received share state change notification, full refresh share paths
+ */
+function receiveShareSyncRefresh(_data: any, plugin: FastSync): void {
+  dump("Receive ShareSyncRefresh, triggering share indicator sync");
+  plugin.shareIndicatorManager?.syncWithServer();
+}
 
 /**
  * 统一处理 SyncEnd 消息的装饰器

--- a/src/lib/share_indicator_manager.ts
+++ b/src/lib/share_indicator_manager.ts
@@ -26,10 +26,6 @@ const ICON_CSS_PROPS = `content: '';
 // Delay sync after startup to avoid competing with Obsidian startup tasks for network resources
 const STARTUP_DELAY_MS = 5000;
 
-// 重连后延迟，等待网络连接稳定
-// Delay after reconnect to wait for network connection to stabilize
-const RECONNECT_DELAY_MS = 2000;
-
 export class ShareIndicatorManager {
     // 内存中的分享路径集合 / In-memory set of shared paths
     private sharedPaths: Set<string> = new Set();
@@ -69,10 +65,10 @@ export class ShareIndicatorManager {
         this.sharedPaths = new Set(saved);
         this.regenerateCss();
 
-        // 注册设备上线事件：重连后增量同步，恢复离线期间的变更
-        // Register online event: incremental sync on reconnect to recover offline changes
+        // 注册设备上线事件：重连后全量同步分享状态
+        // Register online event: full sync share state on reconnect
         this.onlineHandler = () => {
-            setTimeout(() => this.syncWithServer().catch(() => {}), RECONNECT_DELAY_MS);
+            setTimeout(() => this.syncWithServer().catch(() => {}), STARTUP_DELAY_MS);
         };
         window.addEventListener("online", this.onlineHandler);
 
@@ -84,8 +80,8 @@ export class ShareIndicatorManager {
     }
 
     /**
-     * 增量优先的服务端同步：有 lastShareSyncTime 时走增量，否则全量拉取
-     * Delta-first server sync: use incremental if lastShareSyncTime exists, else full refresh
+     * 从服务端全量拉取分享路径并更新本地缓存和 CSS
+     * Full fetch share paths from server, update local cache and CSS
      */
     async syncWithServer(): Promise<void> {
         if (this.isSyncing) return;
@@ -93,53 +89,21 @@ export class ShareIndicatorManager {
         try {
             if (!this.plugin.settings.api || !this.plugin.settings.apiToken) return;
 
-            const lastSyncTime = Number(
-                this.plugin.localStorageManager?.getMetadata("lastShareSyncTime") ?? 0
-            );
+            const paths = await this.plugin.api.getSharePaths();
+            if (paths === null) return; // 网络错误，静默失败 / Network error, fail silently
 
-            if (lastSyncTime > 0) {
-                // 增量同步 / Incremental sync
-                const changes = await this.plugin.api.getShareChanges(lastSyncTime);
-                if (changes === null) return; // 网络错误，静默失败 / Network error, fail silently
+            // 路径集合未变更时跳过写盘和 CSS 重建
+            // Skip saveData and CSS rebuild when path set is unchanged
+            const newSet = new Set(paths);
+            if (this.sharedPaths.size === newSet.size && paths.every(p => this.sharedPaths.has(p))) return;
 
-                if (changes.fullRefreshRequired) {
-                    await this._fullRefresh();
-                } else {
-                    // 应用增量变更 / Apply delta changes
-                    if (changes.removed.length > 0 || changes.added.length > 0) {
-                        for (const p of changes.removed) this.sharedPaths.delete(p);
-                        for (const p of changes.added) this.sharedPaths.add(p);
-                        this.plugin.settings.sharedPaths = Array.from(this.sharedPaths);
-                        await this.plugin.saveData(this.plugin.settings);
-                        this.regenerateCss();
-                    }
-                    // 无论是否有变更，都更新时间戳（缩小下次增量查询范围）
-                    // Always update timestamp regardless of changes (narrow next incremental query range)
-                    this.plugin.localStorageManager?.setMetadata("lastShareSyncTime", changes.lastTime);
-                }
-            } else {
-                // 首次同步，全量拉取 / First sync: full fetch
-                await this._fullRefresh();
-            }
+            this.sharedPaths = newSet;
+            this.plugin.settings.sharedPaths = paths;
+            await this.plugin.saveData(this.plugin.settings);
+            this.regenerateCss();
         } finally {
             this.isSyncing = false;
         }
-    }
-
-    /**
-     * 全量拉取并覆盖本地缓存
-     * Full fetch: overwrite local cache with server's complete active share list
-     */
-    private async _fullRefresh(): Promise<void> {
-        const paths = await this.plugin.api.getSharePaths();
-        if (paths === null) return; // 网络错误，静默失败 / Network error, fail silently
-        this.sharedPaths = new Set(paths);
-        this.plugin.settings.sharedPaths = paths;
-        await this.plugin.saveData(this.plugin.settings);
-        // 记录全量拉取完成的时间戳，供后续增量请求使用
-        // Record timestamp of full fetch completion for future delta requests
-        this.plugin.localStorageManager?.setMetadata("lastShareSyncTime", Date.now());
-        this.regenerateCss();
     }
 
     /**


### PR DESCRIPTION
简化分享状态的同步机制，更稳定。
删除之前为分享状态同步引入的新接口和逻辑： getShareChanges 增量同步逻辑及 lastShareSyncTime 追踪（只是对分享状态更新的接口，不涉及笔记和附件同步的接口）
新增 ShareSyncRefresh WebSocket 消息处理器触发全量刷新，会在笔记、文件、配置同步结束后再同步分享状态，不阻塞主流程。
解决跨设备分享状态不同步的问题。

关联PR：https://github.com/haierkeys/fast-note-sync-service/pull/192