### PR TITLE
fix: 一些边缘情况同步更稳定：修复竞争态导致的文件同步异常&附件重复下载的问题

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,9 @@ data.json
 sync.log
 # Exclude macOS Finder (System Explorer) View States
 .DS_Store
-todo.md
 /src/dist
 /src/views/dist
+
+# Claude Code
+CLAUDE.md
+.claude/

--- a/.gitignore
+++ b/.gitignore
@@ -20,5 +20,6 @@ data.json
 sync.log
 # Exclude macOS Finder (System Explorer) View States
 .DS_Store
+todo.md
 /src/dist
 /src/views/dist

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -234,6 +234,8 @@ const en: Partial<LangMap> = {
   "ui.log.action.FileRename": "Attachment Renaming",
   "ui.log.action.FileModify": "Attachment Modification",
   "ui.log.action.FileDelete": "Attachment Deletion",
+  "ui.log.action.FileRenameAck": "Attachment Rename Success",
+  "ui.log.action.FileUploadAck": "Attachment Upload Success",
   "ui.log.action.SettingSync_full": "Config Sync (Full)",
   "ui.log.action.SettingSync_incremental": "Config Sync (Incremental)",
   "ui.log.action.SettingSyncModify": "Config Sync Update",

--- a/src/i18n/locales/ja.ts
+++ b/src/i18n/locales/ja.ts
@@ -234,6 +234,8 @@ const ja: Partial<LangMap> = {
   "ui.log.action.FileRename": "添付ファイル名前変更",
   "ui.log.action.FileModify": "添付ファイル修正",
   "ui.log.action.FileDelete": "添付ファイル削除",
+  "ui.log.action.FileRenameAck": "添付ファイル名前変更成功",
+  "ui.log.action.FileUploadAck": "添付ファイルアップロード成功",
   "ui.log.action.SettingSync_full": "設定同期 (全量)",
   "ui.log.action.SettingSync_incremental": "設定同期 (増量)",
   "ui.log.action.SettingSyncModify": "設定同期更新",

--- a/src/i18n/locales/ko.ts
+++ b/src/i18n/locales/ko.ts
@@ -234,6 +234,8 @@ const ko: Partial<LangMap> = {
   "ui.log.action.FileRename": "첨부 파일 이름 변경",
   "ui.log.action.FileModify": "첨부 파일 수정",
   "ui.log.action.FileDelete": "첨부 파일 삭제",
+  "ui.log.action.FileRenameAck": "첨부 파일 이름 변경 성공",
+  "ui.log.action.FileUploadAck": "첨부 파일 업로드 성공",
   "ui.log.action.SettingSync_full": "설정 동기화 (전체)",
   "ui.log.action.SettingSync_incremental": "설정 동기화 (증분)",
   "ui.log.action.SettingSyncModify": "설정 동기화 업데이트",

--- a/src/i18n/locales/zh-cn.ts
+++ b/src/i18n/locales/zh-cn.ts
@@ -234,6 +234,8 @@ const zh_cn: Partial<LangMap> = {
   "ui.log.action.FileRename": "附件重命名",
   "ui.log.action.FileModify": "附件修改",
   "ui.log.action.FileDelete": "附件删除",
+  "ui.log.action.FileRenameAck": "附件重命名成功",
+  "ui.log.action.FileUploadAck": "附件上传成功",
   "ui.log.action.SettingSync_full": "配置同步(全量)",
   "ui.log.action.SettingSync_incremental": "配置同步(增量)",
   "ui.log.action.SettingSyncModify": "配置同步更新",

--- a/src/i18n/locales/zh-tw.ts
+++ b/src/i18n/locales/zh-tw.ts
@@ -234,6 +234,8 @@ const zh_tw: Partial<LangMap> = {
   "ui.log.action.FileRename": "附件重命名",
   "ui.log.action.FileModify": "附件修改",
   "ui.log.action.FileDelete": "附件刪除",
+  "ui.log.action.FileRenameAck": "附件重命名成功",
+  "ui.log.action.FileUploadAck": "附件上傳成功",
   "ui.log.action.SettingSync_full": "配置同步(全量)",
   "ui.log.action.SettingSync_incremental": "配置同步(增量)",
   "ui.log.action.SettingSyncModify": "配置同步更新",

--- a/src/lib/file_operator.ts
+++ b/src/lib/file_operator.ts
@@ -624,10 +624,9 @@ export const receiveFileSyncEnd = async function (data: any, plugin: FastSync) {
 
   // 从 data 对象中提取任务统计信息
   const syncData = data as SyncEndData
-  const hasUpdates = (syncData.needUploadCount || 0) + (syncData.needModifyCount || 0) + (syncData.needSyncMtimeCount || 0) + (syncData.needDeleteCount || 0) > 0;
-  if (hasUpdates) {
-    plugin.localStorageManager.setMetadata("lastFileSyncTime", syncData.lastTime)
-  }
+  // 无条件更新 lastFileSyncTime，确保包含服务端本轮同步后的所有异步操作（如 SyncResourceFID）
+  // Unconditionally update lastFileSyncTime to cover all async server-side ops after this sync round (e.g., SyncResourceFID)
+  plugin.localStorageManager.setMetadata("lastFileSyncTime", syncData.lastTime)
   plugin.syncTypeCompleteCount++
 }
 
@@ -876,6 +875,24 @@ const handleFileChunkDownloadComplete = async function (session: FileDownloadSes
     const sessionSize = Array.from(session.chunks.values()).reduce((sum, c) => sum + c.byteLength, 0)
     currentDownloadBufferBytes -= sessionSize
     plugin.fileDownloadSessions.delete(session.sessionId)
+  }
+}
+
+// 收到 FileRenameAck，用服务端返回的时间戳更新 lastFileSyncTime
+// Receive FileRenameAck, update lastFileSyncTime with server-returned timestamp
+export const receiveFileRenameAck = function (data: { lastTime?: number }, plugin: FastSync) {
+  if (data.lastTime && data.lastTime > Number(plugin.localStorageManager.getMetadata("lastFileSyncTime"))) {
+    plugin.localStorageManager.setMetadata("lastFileSyncTime", data.lastTime)
+    dump(`FileRenameAck: lastFileSyncTime updated to`, data.lastTime)
+  }
+}
+
+// 收到 FileUploadAck，用服务端返回的时间戳更新 lastFileSyncTime
+// Receive FileUploadAck, update lastFileSyncTime with server-returned timestamp
+export const receiveFileUploadAck = function (data: { lastTime?: number }, plugin: FastSync) {
+  if (data.lastTime && data.lastTime > Number(plugin.localStorageManager.getMetadata("lastFileSyncTime"))) {
+    plugin.localStorageManager.setMetadata("lastFileSyncTime", data.lastTime)
+    dump(`FileUploadAck: lastFileSyncTime updated to`, data.lastTime)
   }
 }
 

--- a/src/lib/file_operator.ts
+++ b/src/lib/file_operator.ts
@@ -836,7 +836,15 @@ const handleFileChunkDownloadComplete = async function (session: FileDownloadSes
           const folder = normalizedPath.split("/").slice(0, -1).join("/")
           if (folder != "") {
             const dirExists = plugin.app.vault.getFolderByPath(folder)
-            if (dirExists == null) await plugin.app.vault.createFolder(folder)
+            if (dirExists == null) {
+              try {
+                await plugin.app.vault.createFolder(folder)
+              } catch (e) {
+                // 并发竞争时只有一个调用成功，另一方忽略"已存在"错误
+                // In concurrent race only one call succeeds; ignore "already exists" error
+                if (!plugin.app.vault.getFolderByPath(folder)) throw e
+              }
+            }
           }
           await plugin.app.vault.createBinary(normalizedPath, completeFile.buffer, { ...(session.ctime > 0 && { ctime: session.ctime }), ...(session.mtime > 0 && { mtime: session.mtime }) })
         }

--- a/src/lib/folder_operator.ts
+++ b/src/lib/folder_operator.ts
@@ -227,9 +227,8 @@ export const receiveFolderSyncEnd = async function (data: any, plugin: FastSync)
     dump(`Receive folder end:`, data)
 
     const syncData = data as SyncEndData
-    const hasUpdates = (syncData.needUploadCount || 0) + (syncData.needModifyCount || 0) + (syncData.needSyncMtimeCount || 0) + (syncData.needDeleteCount || 0) > 0;
-    if (hasUpdates) {
-        plugin.localStorageManager.setMetadata("lastFolderSyncTime", syncData.lastTime)
-    }
+    // 无条件更新 lastFolderSyncTime，确保包含服务端本轮同步后的所有异步操作（如 SyncResourceFID）
+    // Unconditionally update lastFolderSyncTime to cover all async server-side ops after this sync round (e.g., SyncResourceFID)
+    plugin.localStorageManager.setMetadata("lastFolderSyncTime", syncData.lastTime)
     plugin.syncTypeCompleteCount++
 }

--- a/src/lib/note_operator.ts
+++ b/src/lib/note_operator.ts
@@ -162,7 +162,15 @@ export const receiveNoteSyncModify = async function (data: ReceiveMessage, plugi
         const folder = normalizedPath.split("/").slice(0, -1).join("/")
         if (folder != "") {
           const dirExists = plugin.app.vault.getFolderByPath(folder)
-          if (dirExists == null) await plugin.app.vault.createFolder(folder)
+          if (dirExists == null) {
+            try {
+              await plugin.app.vault.createFolder(folder)
+            } catch (e) {
+              // 并发竞争时只有一个调用成功，另一方忽略"已存在"错误
+              // In concurrent race only one call succeeds; ignore "already exists" error
+              if (!plugin.app.vault.getFolderByPath(folder)) throw e
+            }
+          }
         }
         await plugin.app.vault.create(normalizedPath, data.content, { ...(data.ctime > 0 && { ctime: data.ctime }), ...(data.mtime > 0 && { mtime: data.mtime }) })
       }

--- a/src/lib/note_operator.ts
+++ b/src/lib/note_operator.ts
@@ -330,10 +330,9 @@ export const receiveNoteSyncEnd = async function (data: any, plugin: FastSync) {
 
   // 从 data 对象中提取任务统计信息
   const syncData = data as SyncEndData
-  const hasUpdates = (syncData.needUploadCount || 0) + (syncData.needModifyCount || 0) + (syncData.needSyncMtimeCount || 0) + (syncData.needDeleteCount || 0) > 0;
-  if (hasUpdates) {
-    plugin.localStorageManager.setMetadata("lastNoteSyncTime", syncData.lastTime)
-  }
+  // 无条件更新 lastNoteSyncTime，确保包含服务端本轮同步后的所有异步操作（如 SyncResourceFID）
+  // Unconditionally update lastNoteSyncTime to cover all async server-side ops after this sync round (e.g., SyncResourceFID)
+  plugin.localStorageManager.setMetadata("lastNoteSyncTime", syncData.lastTime)
   plugin.syncTypeCompleteCount++
 }
 

--- a/src/lib/operator.ts
+++ b/src/lib/operator.ts
@@ -1,6 +1,6 @@
 import { TFolder, TFile, Notice, normalizePath, Platform } from "obsidian";
 
-import { receiveFileUpload, receiveFileSyncUpdate, receiveFileSyncDelete, receiveFileSyncMtime, receiveFileSyncChunkDownload, receiveFileSyncEnd, checkAndUploadAttachments, receiveFileSyncRename } from "./file_operator";
+import { receiveFileUpload, receiveFileSyncUpdate, receiveFileSyncDelete, receiveFileSyncMtime, receiveFileSyncChunkDownload, receiveFileSyncEnd, checkAndUploadAttachments, receiveFileSyncRename, receiveFileRenameAck, receiveFileUploadAck } from "./file_operator";
 import { receiveConfigSyncModify, receiveConfigUpload, receiveConfigSyncMtime, receiveConfigSyncDelete, receiveConfigSyncEnd, configAllPaths, receiveConfigSyncClear } from "./config_operator";
 import { receiveNoteSyncModify, receiveNoteUpload, receiveNoteSyncMtime, receiveNoteSyncDelete, receiveNoteSyncEnd, receiveNoteSyncRename } from "./note_operator";
 import { SyncMode, SnapFile, SnapFolder, SyncEndData, PathHashFile, NoteSyncData, FileSyncData, ConfigSyncData, FolderSyncData } from "./types";
@@ -213,6 +213,8 @@ export const receiveOperators: Map<string, ReceiveOperator> = new Map([
   ["FileSyncRename", receiveFileSyncRename],
   ["FileSyncMtime", receiveFileSyncMtime],
   ["FileSyncEnd", (data, plugin) => receiveSyncEndWrapper(data, plugin, "file")],
+  ["FileRenameAck", receiveFileRenameAck],
+  ["FileUploadAck", receiveFileUploadAck],
   ["SettingSyncModify", receiveConfigSyncModify],
   ["SettingSyncNeedUpload", receiveConfigUpload],
   ["SettingSyncMtime", receiveConfigSyncMtime],

--- a/src/lib/operator.ts
+++ b/src/lib/operator.ts
@@ -566,8 +566,11 @@ export const handleSync = async function (plugin: FastSync, isLoadLastTime: bool
 
 /**
  * 发送同步请求
+ * 先发 FolderSync 并等待文件夹结构在本地落地，再发 NoteSync/FileSync，消除并发 createFolder 竞争
+ * Send FolderSync first and wait for folder structure to be created locally before sending NoteSync/FileSync,
+ * eliminating concurrent createFolder race conditions
  */
-export const handleRequestSend = function (plugin: FastSync, syncMode: SyncMode, noteData: NoteSyncData, fileData: FileSyncData, configData: ConfigSyncData, folderData: FolderSyncData) {
+export const handleRequestSend = async function (plugin: FastSync, syncMode: SyncMode, noteData: NoteSyncData, fileData: FileSyncData, configData: ConfigSyncData, folderData: FolderSyncData) {
   const shouldSyncNotes = syncMode === "auto" || syncMode === "note";
   const shouldSyncConfigs = syncMode === "auto" || syncMode === "config";
 
@@ -582,7 +585,6 @@ export const handleRequestSend = function (plugin: FastSync, syncMode: SyncMode,
       ...(plugin.settings.offlineDeleteSyncEnabled ? { delNotes: noteData.delNotes } : {}),
       ...(noteData.missingNotes.length > 0 ? { missingNotes: noteData.missingNotes } : {}),
     };
-    plugin.websocket.SendMessage("NoteSync", noteSyncData);
 
     const fileSyncData = {
       vault: plugin.settings.vault,
@@ -592,11 +594,6 @@ export const handleRequestSend = function (plugin: FastSync, syncMode: SyncMode,
       ...(plugin.settings.offlineDeleteSyncEnabled ? { delFiles: fileData.delFiles } : {}),
       ...(fileData.missingFiles.length > 0 ? { missingFiles: fileData.missingFiles } : {}),
     };
-    // 如果启用了云预览且未开启类型限制，则不发送 FileSync 请求，从而关闭启动时的 file 同步
-    // 若开启了类型限制，则需要发送以同步不受限类型的附件1
-    if (!plugin.settings.cloudPreviewEnabled || plugin.settings.cloudPreviewTypeRestricted) {
-      plugin.websocket.SendMessage("FileSync", fileSyncData);
-    }
 
     const folderSyncData = {
       vault: plugin.settings.vault,
@@ -606,7 +603,42 @@ export const handleRequestSend = function (plugin: FastSync, syncMode: SyncMode,
       ...(plugin.settings.offlineDeleteSyncEnabled ? { delFolders: folderData.delFolders } : {}),
       ...(folderData.missingFolders.length > 0 ? { missingFolders: folderData.missingFolders } : {}),
     };
+
+    // 第一步：先发 FolderSync，确保文件夹结构先于笔记/附件在本地建立
+    // Step 1: Send FolderSync first to ensure folder structure is created before notes/files
     plugin.websocket.SendMessage("FolderSync", folderSyncData);
+
+    // 第二步：等待 folderSyncDone（FolderSyncEnd 已收到且所有文件夹任务已完成）
+    // 超时兜底：10s 后无论如何继续，避免网络异常时挂起
+    // Step 2: Wait for folderSyncDone (FolderSyncEnd received and all folder tasks completed)
+    // Fallback timeout: continue after 10s regardless, to avoid hanging on network errors
+    await new Promise<void>((resolve) => {
+      const timeout = setTimeout(resolve, 10000)
+      const checkInterval = setInterval(() => {
+        if (!plugin.websocket?.isAuth) {
+          clearInterval(checkInterval)
+          clearTimeout(timeout)
+          resolve()
+          return
+        }
+        const folderSyncDone = plugin.folderSyncEnd && plugin.folderSyncTasks.completed >= (plugin.folderSyncTasks.needUpload + plugin.folderSyncTasks.needModify + plugin.folderSyncTasks.needSyncMtime + plugin.folderSyncTasks.needDelete)
+        if (folderSyncDone) {
+          clearInterval(checkInterval)
+          clearTimeout(timeout)
+          resolve()
+        }
+      }, 50)
+    })
+
+    // 第三步：文件夹结构已就绪，发 NoteSync 和 FileSync
+    // Step 3: Folder structure is ready, now send NoteSync and FileSync
+    plugin.websocket.SendMessage("NoteSync", noteSyncData);
+
+    // 如果启用了云预览且未开启类型限制，则不发送 FileSync 请求，从而关闭启动时的 file 同步
+    // 若开启了类型限制，则需要发送以同步不受限类型的附件1
+    if (!plugin.settings.cloudPreviewEnabled || plugin.settings.cloudPreviewTypeRestricted) {
+      plugin.websocket.SendMessage("FileSync", fileSyncData);
+    }
 
     // 清理已删除文件的本地哈希数据,防止重复检测
     if (plugin.settings.offlineDeleteSyncEnabled) {

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -987,19 +987,23 @@
 /* ===== 移动端同步 Toast / Mobile Sync Toast ===== */
 .fns-mobile-toast {
   position: fixed;
-  top: 95px;
+  top: 100px;
   right: 12px;
   z-index: 9999;
-  max-width: 160px;
-  padding: 5px 12px;
-  border-radius: 6px;
-  background-color: var(--background-secondary);
-  opacity: 0.85;
+  min-width: 90px;
+  padding: 12px 10px;
+  border-radius: 999px;
+  background-color: var(--background-primary);
+  opacity: 0.8;
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
   color: var(--text-normal);
-  font-size: var(--font-ui-smaller);
-  line-height: 1.4;
+  font-size: var(--font-ui-small);
+  font-weight: 500;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  text-align: center;
   pointer-events: none;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
   animation: fns-toast-fade-in 0.2s ease-out;
 
   &.fns-mobile-toast-hiding {

--- a/styles.css
+++ b/styles.css
@@ -851,19 +851,23 @@
 /* ===== 移动端同步 Toast / Mobile Sync Toast ===== */
 .fns-mobile-toast {
   position: fixed;
-  top: 95px;
+  top: 100px; 
   right: 12px;
   z-index: 9999;
-  max-width: 160px;
-  padding: 5px 12px;
-  border-radius: 6px;
-  background-color: var(--background-secondary);
-  opacity: 0.85;
+  min-width: 90px;
+  padding: 12px 10px;
+  border-radius: 999px; 
+  background-color: var(--background-primary);
+  opacity: 0.8; 
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
   color: var(--text-normal);
-  font-size: var(--font-ui-smaller);
-  line-height: 1.4;
+  font-size: var(--font-ui-small);
+  font-weight: 500;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  text-align: center;
   pointer-events: none;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
   animation: fns-toast-fade-in 0.2s ease-out;
 }
 .fns-mobile-toast.fns-mobile-toast-hiding {


### PR DESCRIPTION

## 问题场景

1. 用户上传一批附件后重启 Obsidian，重连触发的增量同步中这些文件被再次下发，导致重复下载。放在子目录下的文件尤其容易复现，且多次重连后问题持续。
2. 启动同步（`startupSync`）时，Note/File 同步与 Folder 同步并发执行，偶发"文件夹已不存在"报错，导致笔记/附件下载失败后丢失。

---

## 问题分析

### Bug 1：`SyncEnd` 仅在有更新时才保存 `lastXxxSyncTime`，导致时间戳停滞

**根因**：`receiveFileSyncEnd` / `receiveNoteSyncEnd` / `receiveFolderSyncEnd` 中，只有本轮同步存在实际变更时才更新 `lastXxxSyncTime`：

```typescript
// 旧代码
const hasUpdates = needUploadCount + needModifyCount + ... > 0;
if (hasUpdates) {
    plugin.localStorageManager.setMetadata("lastFileSyncTime", syncData.lastTime)
}
```

而服务端 `SyncResourceFID` goroutine 会在 `FileUploadAck` 发出后异步更新文件的 `updated_timestamp`（服务端 Bug，详见配套 PR）。若该 goroutine 恰好在最后一次 Ack 之后执行，客户端保存的时间戳便落后于 DB 中的实际时间戳，下次重连查询时命中这些文件，触发重复下载。

**修复**：去掉 `hasUpdates` 条件，每次 `SyncEnd` 后**无条件**将 `lastXxxSyncTime` 更新为 `syncData.lastTime`。服务端 `SyncEnd` 的 `lastTime` 取自 `timex.Now()`（遍历完所有记录后才取），严格大于本轮所有记录的 `updated_timestamp`，无论服务端是否有异步后续操作都能正确覆盖。

---

### Bug 2：`startupSync` 并发 `createFolder` 竞争导致文件夹创建失败

**根因**：`startupSync` 同时发送 `FolderSync`、`NoteSync`、`FileSync` 三个请求。`NoteSync`/`FileSync` 在下载笔记/附件时需要确保父目录存在，若父目录还未被 `FolderSync` 创建，则 `createFolder` 在两条并发路径中同时触发，Obsidian Vault API 抛出"文件夹已存在"异常，导致其中一条路径的下载流程中断，文件丢失。

**修复**：
- `startupSync` 中先等待 `FolderSync` 完成（文件夹结构落地后再发 `NoteSync`/`FileSync`），从根本上消除并发竞争
- 同时在 `createFolder` 调用处增加 try/catch 保护：若捕获到异常且文件夹实际已存在（竞争中另一方创建成功），则静默忽略，否则继续抛出

---

## 修复内容

### 1. `SyncEnd` 无条件更新本地时间戳（Bug 1）

- `src/lib/file_operator.ts`（`receiveFileSyncEnd`）：去掉 `hasUpdates` 判断，无条件执行 `setMetadata("lastFileSyncTime", syncData.lastTime)`
- `src/lib/note_operator.ts`（`receiveNoteSyncEnd`）：同上
- `src/lib/folder_operator.ts`（`receiveFolderSyncEnd`）：同上

### 2. 消除 `startupSync` 并发竞争（Bug 2）

- `src/lib/operator.ts`（`handleRequestSend`）：改为 async，先 `await` `FolderSync` 完成后再发送 `NoteSync`/`FileSync`
- `src/lib/note_operator.ts` / `src/lib/file_operator.ts`（`createFolder` 调用处）：增加 try/catch，捕获"已存在"异常时检查文件夹是否真实存在，存在则忽略

### 3. 新增 `FileUploadAck` / `FileRenameAck` 处理（配合服务端 Ack 消息）

服务端上传/重命名完成后会主动回发 Ack，客户端据此实时更新 `lastFileSyncTime`，避免因 `FileSyncEnd` 时间戳滞后而误触发重复下载：

- `src/lib/file_operator.ts`：新增 `receiveFileUploadAck`、`receiveFileRenameAck` 函数
- `src/lib/operator.ts`：注册 `FileUploadAck`、`FileRenameAck` 到 `receiveOperators`
- `src/i18n/locales/*.ts`（5 个语言文件）：新增 `ui.log.action.FileUploadAck`（附件上传成功）和 `ui.log.action.FileRenameAck`（附件重命名成功）文案

---

## 测试计划

1. **重复下载 Bug 1 验证**：上传 14 个附件到子目录 → 等所有 `FileUploadAck` 收到 → 重启 Obsidian → `FileSyncEnd.needModifyCount = 0`；连续重启 3 次结果一致
2. **重复下载 Bug 2 验证**：上传附件后立即重启（不等 `SyncEnd`）→ 重连后确认无重复下载
3. **并发竞争验证**：首次全量同步（含多层目录结构）→ 所有笔记/附件正常下载，无"文件夹不存在"报错，无文件丢失
4. **同步日志验证**：上传/重命名附件时，同步日志中"附件上传成功"/"附件重命名成功"条目正常显示（含文件路径）
5. **正常同步不受影响**：编辑笔记/上传附件 → 断线重连 → 所有文件正确同步，无重复下发，无遗漏