### PR TITLE
Fix: 两个边缘场景导致附件被误删

### DIFF
--- a/src/lib/events_manager.ts
+++ b/src/lib/events_manager.ts
@@ -2,8 +2,8 @@ import { TAbstractFile, Platform, TFile, TFolder, Menu, MenuItem, normalizePath 
 
 import { folderModify, folderDelete, folderRename } from "./folder_operator";
 import { NoteHistoryModal } from "../views/note-history/history-modal";
-import { noteModify, noteDelete, noteRename } from "./note_operator";
-import { fileModify, fileDelete, fileRename } from "./file_operator";
+import { noteModify, noteDelete, noteRename, noteDeleteByPath } from "./note_operator";
+import { fileModify, fileDelete, fileRename, fileDeleteByPath } from "./file_operator";
 import { dump, isPathInConfigSyncDirs } from "./helps";
 import type FastSync from "../main";
 import { $ } from "../i18n/lang";
@@ -176,34 +176,22 @@ export class EventManager {
           const oldExt = oldFile.match(/\.([^.]+)$/)?.[1] ?? ''
           let isDiffFileType = file.extension !== oldExt
           if (isDiffFileType) {
-            //获取旧文件的TFile对象
-            const oldTFile = this.plugin.app.vault.getAbstractFileByPath(oldFile) as TAbstractFile
-            this.runWithDelay(oldTFile.path, () => {            
-              //如果旧文件是markdown文件，则发送笔记删除消息，否则发送文件删除消息
-              if(oldTFile.path.endsWith(".md"))
-              {
-                //dump(`rename,now delete old note.`,oldTFile.path)
-                noteDelete(oldTFile, this.plugin, true)
-              }
-              else{
-                //dump(`rename,now delete old file.`,oldTFile.path)
-                fileDelete(oldTFile, this.plugin, true)
-              }
-            },0)
-
-            this.runWithDelay(file.path, () => {            
-              //如果新文件是markdown文件，则发送笔记创建消息，否则发送文件创建消息
-              if(file.path.endsWith(".md"))
-              {
-                //dump(`rename,now modify new note.`,oldTFile.path)
-                noteModify(file, this.plugin, true)
-              }
+            // 修复：rename 完成后旧路径的 TFile 已不存在，直接使用路径字符串避免空指针崩溃
+            // Fix: TFile of old path no longer exists after rename completes, use path string to avoid null pointer crash
+            this.runWithDelay(oldFile, () => {
+              if (oldFile.endsWith(".md"))
+                noteDeleteByPath(oldFile, this.plugin)
               else
-              {
-                //dump(`rename,now modify new file.`,oldTFile.path)
+                fileDeleteByPath(oldFile, this.plugin)
+            }, 0)
+
+            this.runWithDelay(file.path, () => {
+              //如果新文件是markdown文件，则发送笔记创建消息，否则发送文件创建消息
+              if (file.path.endsWith(".md"))
+                noteModify(file, this.plugin, true)
+              else
                 fileModify(file, this.plugin, true)
-              }
-            },0)            
+            }, 0)
           }
           else{
             if (file.path.endsWith(".md")) {

--- a/src/lib/file_operator.ts
+++ b/src/lib/file_operator.ts
@@ -124,6 +124,43 @@ export const fileDelete = async function (file: TAbstractFile, plugin: FastSync,
 }
 
 /**
+ * 按路径字符串发送文件删除消息（用于无法获取 TFile 对象的场景，如 rename 后旧路径已不存在）
+ * Send file delete message by path string (for scenarios where TFile object is unavailable, e.g., old path after rename)
+ */
+export const fileDeleteByPath = async function (filePath: string, plugin: FastSync) {
+  if (plugin.settings.syncEnabled == false || plugin.settings.readonlySyncEnabled) return
+  if (filePath.endsWith(".md")) return
+  if (isPathExcluded(filePath, plugin)) return
+  if (plugin.lastSyncPathDeleted.has(filePath)) return
+
+  await plugin.lockManager.withLock(filePath, async () => {
+    // 如果该文件正在上传或在队列中，则标记为取消，且不再发送服务端删除消息
+    // If the file is being uploaded or in the queue, cancel and skip server delete
+    if (activeUploadsMap.has(filePath)) {
+      activeUploadsMap.get(filePath)!.cancelled = true;
+      plugin.fileHashManager.removeFileHash(filePath)
+      return
+    }
+
+    plugin.addIgnoredFile(filePath)
+    try {
+      plugin.websocket.SendMessage("FileDelete", {
+        vault: plugin.settings.vault,
+        path: filePath,
+        pathHash: hashContent(filePath),
+      })
+      dump(`File delete by path send`, filePath)
+
+      // WebSocket 消息发送后从哈希表中删除
+      // Remove from hash map after sending WebSocket message
+      plugin.fileHashManager.removeFileHash(filePath)
+    } finally {
+      plugin.removeIgnoredFile(filePath)
+    }
+  }, { maxRetries: 3, retryInterval: 50 });
+}
+
+/**
  * 文件重命名事件处理
  */
 export const fileRename = async function (file: TAbstractFile, oldfile: string, plugin: FastSync, eventEnter: boolean = false) {
@@ -418,12 +455,8 @@ export const receiveFileSyncUpdate = async function (data: ReceiveFileSyncUpdate
   plugin.websocket.SendMessage("FileChunkDownload", requestData)
   plugin.totalFilesToDownload++
 
-  // 服务端推送文件更新,更新哈希表(使用内容哈希)
-  plugin.fileHashManager.setFileHash(data.path, data.contentHash)
-  // 记录 mtime
-  plugin.lastSyncMtime.set(data.path, data.mtime)
-
   // 更新同步时间
+  // Update sync time
   if (data.lastTime && data.lastTime > Number(plugin.localStorageManager.getMetadata("lastFileSyncTime"))) {
     plugin.localStorageManager.setMetadata("lastFileSyncTime", data.lastTime)
   }

--- a/src/lib/note_operator.ts
+++ b/src/lib/note_operator.ts
@@ -93,6 +93,35 @@ export const noteDelete = async function (file: TAbstractFile, plugin: FastSync,
 }
 
 /**
+ * 按路径字符串发送笔记删除消息（用于无法获取 TFile 对象的场景，如 rename 后旧路径已不存在）
+ * Send note delete message by path string (for scenarios where TFile object is unavailable, e.g., old path after rename)
+ */
+export const noteDeleteByPath = async function (filePath: string, plugin: FastSync) {
+  if (plugin.settings.syncEnabled == false || plugin.settings.readonlySyncEnabled) return
+  if (!filePath.endsWith(".md")) return
+  if (isPathExcluded(filePath, plugin)) return
+  if (plugin.lastSyncPathDeleted.has(filePath)) return
+
+  await plugin.lockManager.withLock(filePath, async () => {
+    plugin.addIgnoredFile(filePath)
+    try {
+      plugin.websocket.SendMessage("NoteDelete", {
+        vault: plugin.settings.vault,
+        path: filePath,
+        pathHash: hashContent(filePath),
+      })
+      dump(`Note delete by path send`, filePath)
+
+      // WebSocket 消息发送后从哈希表中删除
+      // Remove from hash map after sending WebSocket message
+      plugin.fileHashManager.removeFileHash(filePath)
+    } finally {
+      plugin.removeIgnoredFile(filePath)
+    }
+  }, { maxRetries: 3, retryInterval: 50 });
+}
+
+/**
  * 笔记重命名事件处理
  */
 export const noteRename = async function (file: TAbstractFile, oldfile: string, plugin: FastSync, eventEnter: boolean = false) {


### PR DESCRIPTION
## 问题一：附件下载过程中中断（如网络中断、Obsidian被关闭等）被误判为离线删除，导致服务端删除并同步到其他设备

### 复现场景（多设备）：

设备 A 从剪贴板粘贴截图 → 上传到服务端成功
设备 B 触发同步，服务端推送 FileSyncUpdate
设备 B 开始分片下载图片，中途 Obsidian 关闭或网络中断
设备 B 重新启动，触发同步
设备 A 的图片被删除，移入回收站

### 根本原因：

`receiveFileSyncUpdate` 在发送 `FileChunkDownload` 请求后，立即调用了 `setFileHash` 和 `lastSyncMtime`，但此时文件尚未下载到本地 vault。

```typescript
// 发送下载请求（异步，不等待下载完成）
plugin.websocket.SendMessage("FileChunkDownload", requestData)

// ⚠️ 提前写入——文件根本还没下载！
plugin.fileHashManager.setFileHash(data.path, data.contentHash)
plugin.lastSyncMtime.set(data.path, data.mtime)
```

一旦下载中断，hashmap 记录了该文件，但 vault 里没有。下次重启触发 `offlineDeleteSyncEnabled` 逻辑时，发现 hashmap 有、vault 无，便将其放入 `delFiles` 发给服务端，服务端删除后广播 `FileSyncDelete` 给所有设备。

### 修复：

删除这两行提前写入。下载完成回调（`receiveFileChunkDownload`）中已有时机正确的写入，无需重复。

---

## 问题二：附件更改扩展名后导致被误删

### 复现场景：

使用 obsidian-image-converter 等插件对已同步的图片执行"批量处理"，将 `photo.png` 转换为 `photo.webp`，触发 rename 事件，且新旧扩展名不同（`isDiffFileType = true`）。

### 根本原因：空指针

`watchRename` 的 `isDiffFileType` 分支通过 `getAbstractFileByPath(oldFile)` 获取旧文件的 TFile 对象，但 rename 完成后旧路径已不存在，返回 `null`，随后访问 `null.path` 直接崩溃。

```typescript
// rename 完成后 oldFile 路径已不存在，返回 null
const oldTFile = this.plugin.app.vault.getAbstractFileByPath(oldFile) as TAbstractFile
this.runWithDelay(oldTFile.path, ...) // ⚠️ 空指针崩溃
```

连锁后果：
- 旧文件的删除消息未发出 → 服务端保留旧文件
- `pendingRenamePaths` 不被清理 → 新文件后续的 modify 事件被永久阻断，新文件无法上传

### 修复：

新增 `fileDeleteByPath` / `noteDeleteByPath`，直接接收路径字符串，复用完整的保护逻辑（`lockManager`、`activeUploadsMap`、`addIgnoredFile` 等），替换掉需要 TFile 对象的旧调用。