### PR TITLE
修复 Linux 上初始同步后无法发送本地改动的问题

### DIFF
--- a/src/lib/folder_operator.ts
+++ b/src/lib/folder_operator.ts
@@ -116,22 +116,32 @@ export const receiveFolderSyncModify = async function (data: any, plugin: FastSy
 
     const normalizedPath = normalizePath(data.path)
 
-    await plugin.lockManager.withLock(normalizedPath, async () => {
-        plugin.addIgnoredFile(normalizedPath)
-        try {
-            const existingFolder = plugin.app.vault.getAbstractFileByPath(normalizedPath)
-            if (!existingFolder) {
-                await plugin.app.vault.createFolder(normalizedPath)
+    try {
+        await plugin.lockManager.withLock(normalizedPath, async () => {
+            plugin.addIgnoredFile(normalizedPath)
+            try {
+                const existingFolder = plugin.app.vault.getAbstractFileByPath(normalizedPath)
+                if (!existingFolder) {
+                    try {
+                        await plugin.app.vault.createFolder(normalizedPath)
+                    } catch (e) {
+                        // 文件夹可能因并发创建已存在（Linux 上会抛 "Folder already exists"），忽略此错误
+                        // Folder may already exist due to concurrent creation (Linux throws "Folder already exists"), ignore
+                        dump(`Folder create ignored (may already exist): ${normalizedPath}`, e)
+                    }
+                }
+                plugin.folderSnapshotManager.setFolderMtime(normalizedPath, data.mtime || Date.now())
+            } finally {
+                setTimeout(() => {
+                    plugin.removeIgnoredFile(normalizedPath)
+                }, 500);
             }
-            plugin.folderSnapshotManager.setFolderMtime(normalizedPath, data.mtime || Date.now())
-        } finally {
-            setTimeout(() => {
-                plugin.removeIgnoredFile(normalizedPath)
-            }, 500);
-        }
-    }, { maxRetries: 5, retryInterval: 100 });
-
-    plugin.folderSyncTasks.completed++
+        }, { maxRetries: 5, retryInterval: 100 });
+    } catch (e) {
+        dump(`Error in receiveFolderSyncModify: ${normalizedPath}`, e)
+    } finally {
+        plugin.folderSyncTasks.completed++
+    }
 }
 
 /**
@@ -147,27 +157,31 @@ export const receiveFolderSyncDelete = async function (data: any, plugin: FastSy
 
     const normalizedPath = normalizePath(data.path)
 
-    await plugin.lockManager.withLock(normalizedPath, async () => {
-        const folder = plugin.app.vault.getAbstractFileByPath(normalizedPath)
-        if (folder instanceof TFolder) {
-            plugin.addIgnoredFile(normalizedPath)
-            try {
-                // 必须检测并等到 目录里的所有文件数量 为 0 之后再执行
-                await waitForFolderEmpty(normalizedPath, plugin);
-                // 记录待删除路径
-                plugin.lastSyncPathDeleted.add(normalizedPath)
-                await plugin.app.vault.delete(folder, true)
-                plugin.folderSnapshotManager.removeFolder(normalizedPath)
-            } finally {
-                setTimeout(() => {
-                    plugin.removeIgnoredFile(normalizedPath)
-                    plugin.lastSyncPathDeleted.delete(normalizedPath)
-                }, 500);
+    try {
+        await plugin.lockManager.withLock(normalizedPath, async () => {
+            const folder = plugin.app.vault.getAbstractFileByPath(normalizedPath)
+            if (folder instanceof TFolder) {
+                plugin.addIgnoredFile(normalizedPath)
+                try {
+                    // 必须检测并等到 目录里的所有文件数量 为 0 之后再执行
+                    await waitForFolderEmpty(normalizedPath, plugin);
+                    // 记录待删除路径
+                    plugin.lastSyncPathDeleted.add(normalizedPath)
+                    await plugin.app.vault.delete(folder, true)
+                    plugin.folderSnapshotManager.removeFolder(normalizedPath)
+                } finally {
+                    setTimeout(() => {
+                        plugin.removeIgnoredFile(normalizedPath)
+                        plugin.lastSyncPathDeleted.delete(normalizedPath)
+                    }, 500);
+                }
             }
-        }
-    }, { maxRetries: 10, retryInterval: 200 });
-
-    plugin.folderSyncTasks.completed++
+        }, { maxRetries: 10, retryInterval: 200 });
+    } catch (e) {
+        dump(`Error in receiveFolderSyncDelete: ${normalizedPath}`, e)
+    } finally {
+        plugin.folderSyncTasks.completed++
+    }
 }
 
 /**
@@ -185,41 +199,49 @@ export const receiveFolderSyncRename = async function (data: FolderSyncRenameMes
     const normalizedOldPath = normalizePath(data.oldPath)
     const normalizedNewPath = normalizePath(data.path)
 
-    await plugin.lockManager.withLock(normalizedNewPath, async () => {
-        const folder = plugin.app.vault.getAbstractFileByPath(normalizedOldPath)
-        if (folder instanceof TFolder) {
-            plugin.addIgnoredFile(normalizedNewPath)
-            plugin.addIgnoredFile(normalizedOldPath)
+    try {
+        await plugin.lockManager.withLock(normalizedNewPath, async () => {
+            const folder = plugin.app.vault.getAbstractFileByPath(normalizedOldPath)
+            if (folder instanceof TFolder) {
+                plugin.addIgnoredFile(normalizedNewPath)
+                plugin.addIgnoredFile(normalizedOldPath)
 
-            // 记录新路径
-            plugin.lastSyncPathRenamed.add(normalizedNewPath)
+                // 记录新路径
+                plugin.lastSyncPathRenamed.add(normalizedNewPath)
 
-            try {
-                const target = plugin.app.vault.getAbstractFileByPath(normalizedNewPath)
-                if (target) {
-                    await plugin.app.vault.delete(target, true)
+                try {
+                    const target = plugin.app.vault.getAbstractFileByPath(normalizedNewPath)
+                    if (target) {
+                        await plugin.app.vault.delete(target, true)
+                    }
+
+                    await plugin.app.vault.rename(folder, normalizedNewPath)
+                    plugin.folderSnapshotManager.removeFolder(normalizedOldPath)
+                    plugin.folderSnapshotManager.setFolderMtime(normalizedNewPath, data.mtime || Date.now())
+                } finally {
+                    setTimeout(() => {
+                        plugin.removeIgnoredFile(normalizedNewPath)
+                        plugin.removeIgnoredFile(normalizedOldPath)
+                        plugin.lastSyncPathRenamed.delete(normalizedNewPath)
+                    }, 500);
                 }
-
-                await plugin.app.vault.rename(folder, normalizedNewPath)
-                plugin.folderSnapshotManager.removeFolder(normalizedOldPath)
-                plugin.folderSnapshotManager.setFolderMtime(normalizedNewPath, data.mtime || Date.now())
-            } finally {
-                setTimeout(() => {
-                    plugin.removeIgnoredFile(normalizedNewPath)
-                    plugin.removeIgnoredFile(normalizedOldPath)
-                    plugin.lastSyncPathRenamed.delete(normalizedNewPath)
-                }, 500);
+            } else {
+                const target = plugin.app.vault.getAbstractFileByPath(normalizedNewPath)
+                if (!target) {
+                    try {
+                        await plugin.app.vault.createFolder(normalizedNewPath)
+                    } catch (e) {
+                        dump(`Folder create ignored (may already exist): ${normalizedNewPath}`, e)
+                    }
+                    plugin.folderSnapshotManager.setFolderMtime(normalizedNewPath, data.mtime || Date.now())
+                }
             }
-        } else {
-            const target = plugin.app.vault.getAbstractFileByPath(normalizedNewPath)
-            if (!target) {
-                await plugin.app.vault.createFolder(normalizedNewPath)
-                plugin.folderSnapshotManager.setFolderMtime(normalizedNewPath, data.mtime || Date.now())
-            }
-        }
-    }, { maxRetries: 10, retryInterval: 100 });
-
-    plugin.folderSyncTasks.completed++
+        }, { maxRetries: 10, retryInterval: 100 });
+    } catch (e) {
+        dump(`Error in receiveFolderSyncRename: ${normalizedOldPath} -> ${normalizedNewPath}`, e)
+    } finally {
+        plugin.folderSyncTasks.completed++
+    }
 }
 
 /**

--- a/src/lib/operator.ts
+++ b/src/lib/operator.ts
@@ -56,7 +56,27 @@ export const rebuildAllHashes = async (plugin: FastSync) => {
 /**
  * 检查同步是否完成
  */
-export function checkSyncCompletion(plugin: FastSync, intervalId?: ReturnType<typeof setTimeout>) {
+export function checkSyncCompletion(plugin: FastSync, intervalId?: ReturnType<typeof setTimeout>, syncStartTime?: number) {
+  // 超时保底：如果同步超过 60 秒仍未完成，强制结束并恢复 watch，防止因任务计数异常导致永远无法发送
+  // Safety timeout: if sync exceeds 60s, force completion and re-enable watch to prevent permanent send blockage
+  const SYNC_TIMEOUT_MS = 60000;
+  if (syncStartTime && Date.now() - syncStartTime > SYNC_TIMEOUT_MS) {
+    if (intervalId) clearInterval(intervalId);
+    dump(`Sync completion timeout after ${SYNC_TIMEOUT_MS}ms, force enabling watch. Tasks: note=${JSON.stringify(plugin.noteSyncTasks)}, file=${JSON.stringify(plugin.fileSyncTasks)}, folder=${JSON.stringify(plugin.folderSyncTasks)}, config=${JSON.stringify(plugin.configSyncTasks)}`)
+    plugin.enableWatch();
+    plugin.syncTypeCompleteCount = 0;
+    plugin.resetSyncTasks();
+    plugin.totalFilesToDownload = 0;
+    plugin.downloadedFilesCount = 0;
+    plugin.totalChunksToDownload = 0;
+    plugin.downloadedChunksCount = 0;
+    plugin.totalChunksToUpload = 0;
+    plugin.uploadedChunksCount = 0;
+    plugin.updateStatusBar($("ui.status.completed"));
+    setTimeout(() => plugin.updateStatusBar(""), 3000);
+    return;
+  }
+
   const ws = plugin.websocket.ws;
   const bufferedAmount = ws && ws.readyState === WebSocket.OPEN ? ws.bufferedAmount : 0;
 
@@ -569,8 +589,10 @@ export const handleSync = async function (plugin: FastSync, isLoadLastTime: bool
   }
 
   // 启动进度检测循环,每 100ms 检测一次(更频繁以获得更平滑的进度更新)
+  // 同时记录开始时间，用于超时保底
+  const syncStartTime = Date.now();
   const progressCheckInterval = setInterval(() => {
-    checkSyncCompletion(plugin, progressCheckInterval);
+    checkSyncCompletion(plugin, progressCheckInterval, syncStartTime);
   }, 100);
 };
 


### PR DESCRIPTION
## 问题描述

在 Ubuntu/Linux 上安装插件后，能够成功连接远端 sync 服务器并**接收**消息，但**本地的改动无法发送**出去。macOS 上同样的插件工作正常。

## 根因分析

通过在 Ubuntu 的 Obsidian 开发者控制台排查，发现：

1. **`isWatchEnabled` 卡在 `false`**：初始同步完成后，`checkSyncCompletion` 永远判定同步未完成，`enableWatch()` 不会被调用
2. **`folderSyncTasks` 计数不匹配**：服务端报告 26 个文件夹任务（25 modify + 1 delete），但只有 3 个完成
3. **控制台出现 23 次 `Uncaught (in promise) Error: Folder already exists.`**

具体原因链路：

- `websocket.ts` 的 `onmessage` 调用 receive handler 时**没有 `await`**（第 264 行），导致多个 `FolderSyncModify` 消息**并发处理**
- 并发场景下，A 和 B 都通过了 `if (!existingFolder)` 检查，A 先创建成功，B 再创建时 `vault.createFolder()` 抛出 "Folder already exists" 异常
- **macOS 的 Obsidian 对此错误是容错的**（不抛异常），但 **Linux 上会抛异常**
- 异常导致 `folderSyncTasks.completed++` 被跳过（它在 `await withLock(...)` 之后，异常传播后执行不到）
- `checkSyncCompletion` 检测到 `completed < total`，永远不会调用 `enableWatch()`
- `isWatchEnabled = false` 导致所有本地文件变更事件被静默丢弃，send 功能完全失效

## 修复内容

### 1. `folder_operator.ts`：确保 `completed++` 始终执行

为 `receiveFolderSyncModify`、`receiveFolderSyncDelete`、`receiveFolderSyncRename` 三个函数：
- 外层增加 `try-catch-finally`，将 `completed++` 放入 `finally` 块，无论是否异常都会执行
- `createFolder` 增加内层 `try-catch`，捕获并忽略"文件夹已存在"错误（竞态场景下的正常现象）

### 2. `operator.ts`：`checkSyncCompletion` 增加超时保底

- 记录同步开始时间，如果超过 60 秒仍未完成，强制调用 `enableWatch()` 并清理状态
- 防止因任何原因导致的任务计数异常永久阻塞发送功能
- 超时时会输出详细的任务计数日志，方便排查

## 测试

- 编译通过（`npm run build` 无报错）
- 修复后 Linux 上的 "Folder already exists" 错误会被捕获并忽略，`completed` 计数正确，初始同步正常完成，`isWatchEnabled` 恢复为 `true`，本地改动可以正常发送

🤖 Generated with [Claude Code](https://claude.com/claude-code)