### PR TITLE
fix: 调整ribbon按钮位置后，重启Obsidian后能够保留位置

### DIFF
--- a/src/lib/menu_manager.ts
+++ b/src/lib/menu_manager.ts
@@ -32,8 +32,9 @@ export class MenuManager {
     this.plugin = plugin;
   }
 
-  init() {
-    // 初始化 Ribbon 图标
+  // 必须在 onLayoutReady 之前调用，确保 Obsidian 恢复 ribbon 排序时按钮已存在
+  // Must be called before onLayoutReady so Obsidian can correctly restore ribbon order
+  initRibbon() {
     const initialIcon = Platform.isMobile ? "wifi" : "wifi-off";
     this.ribbonIcon = this.plugin.addRibbonIcon(initialIcon, $("ui.menu.ribbon_title"), (event: MouseEvent) => {
       this.showRibbonMenu(event);
@@ -46,19 +47,25 @@ export class MenuManager {
     // Obsidian 拖动重新排序时，可能会清理该元素的 innerHTML 并重新应用初始注册的 wifi-off 图标，
     // 导致我们的动态状态和红点（badge）丢失。
     // 如果发现预期的图标或红点丢失，立刻自我修复。
+    // Ultimate guard: directly observe DOM changes on the ribbonIcon element.
+    // When Obsidian re-orders ribbon via drag, it may clear innerHTML and re-apply the initially registered icon,
+    // causing our dynamic state and badge to be lost. Self-repair immediately if expected icon or badge is missing.
     const observer = new MutationObserver(() => {
       if (!this.ribbonIcon) return;
       const expectedIconId = Platform.isMobile ? "wifi" : (this.ribbonIconStatus ? "wifi" : "wifi-off");
       const hasCorrectIcon = this.ribbonIcon.querySelector(`.lucide-${expectedIconId}`);
       const hasBadge = this.badgeEl && this.badgeEl.parentElement === this.ribbonIcon;
-      
+
       // 只要预期图标和红点还在，就不干涉（比如 iconic 追加了另一个 SVG，不影响我们的存在）
+      // Only repair if expected icon or badge is missing (e.g. iconic appending another SVG is fine)
       if (!hasCorrectIcon || !hasBadge) {
         this.updateRibbonIcon(this.ribbonIconStatus);
       }
     });
     observer.observe(this.ribbonIcon, { childList: true, subtree: true });
+  }
 
+  init() {
     // 初始化状态栏进度
     this.statusBarItem = this.plugin.addStatusBarItem();
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -34,6 +34,7 @@ export default class FastSync extends Plugin {
   lockManager: LockManager // 锁管理器
   eventManager: EventManager // 事件管理器
   menuManager: MenuManager // 菜单管理器
+  private menuManagerInitialized: boolean = false // 防止 onLayoutReady 重复初始化 / Guard against duplicate onLayoutReady init
   shareIndicatorManager: ShareIndicatorManager // 分享指示器管理器 / Share indicator manager
   fileHashManager: FileHashManager // 文件哈希管理器
   configHashManager: ConfigHashManager // 配置哈希管理器
@@ -242,10 +243,18 @@ export default class FastSync extends Plugin {
       console.warn(`Fast Note Sync: Protocol handler ${ssoAction} registration skipped or already exists. / 协议处理器注册跳过或已存在:`, e);
     }
 
-    // 大部分初始化逻辑移动到 onLayoutReady 之后，避免阻塞 Obsidian 启动16
+    // 提前创建 MenuManager 并初始化 ribbon，必须在 onLayoutReady 之前完成，
+    // 这样 Obsidian 应用保存的 ribbon 排序配置时按钮已存在，用户调整的位置才能被正确恢复。
+    // Create MenuManager and init ribbon before onLayoutReady so that when Obsidian
+    // applies the saved ribbon order config, the button already exists and its position is preserved.
+    this.menuManager = new MenuManager(this)
+    this.menuManager.initRibbon()
+
+    // 大部分初始化逻辑移动到 onLayoutReady 之后，避免阻塞 Obsidian 启动
     this.app.workspace.onLayoutReady(async () => {
       // 防止重复初始化 (Prevent duplicate initialization)
-      if (this.menuManager) return;
+      if (this.menuManagerInitialized) return;
+      this.menuManagerInitialized = true
 
       // 1. 初始化统计和日志 (UI)
       SyncLogManager.getInstance().init(this)
@@ -260,8 +269,8 @@ export default class FastSync extends Plugin {
         },
       });
 
-      // 3. 初始化 UI 管理器
-      this.menuManager = new MenuManager(this)
+      // 3. 初始化 UI 管理器（ribbon 已在 onLayoutReady 之前创建，这里只完成其余初始化）
+      // UI manager: ribbon was already created before onLayoutReady; finish the rest here
       this.menuManager.init()
 
       // 注册 WebSocket 状态监听 (Register WebSocket status listener)


### PR DESCRIPTION
## Problem / 问题

After the user manually reorders the fast-note-sync ribbon button (e.g. moves it to position 1), the position resets to the last slot on every Obsidian restart.

用户在 Obsidian 中手动调整 fast-note-sync 的 ribbon 按钮位置（如移动到第一位）后，每次重启 Obsidian 按钮位置都会复位到最后一个。

## Root Cause / 根本原因

Obsidian restores the saved ribbon order **before** `onLayoutReady` fires. The plugin was calling `addRibbonIcon` inside the `onLayoutReady` callback, so the button was always appended after Obsidian had already finished applying the saved order — making the saved position ineffective.

Obsidian 在 `onLayoutReady` 触发**之前**就已完成 ribbon 排序的恢复。而插件原本在 `onLayoutReady` 回调内部才调用 `addRibbonIcon`，此时 Obsidian 已经应用完保存的排序配置，新加入的按钮只能被追加到末尾，导致用户保存的位置始终无效。

## Fix / 修复方案

Split `MenuManager.init()` into two phases:

- **`initRibbon()`** — creates the ribbon button and sets up the MutationObserver. Called in `onload` **before** `onLayoutReady`, so the button exists when Obsidian applies the saved ribbon order.
- **`init()`** — handles everything else (status bar, commands, etc.). Still called inside `onLayoutReady` as before.

将 `MenuManager.init()` 拆分为两个阶段：

- **`initRibbon()`** — 创建 ribbon 按钮并设置 MutationObserver，在 `onload` 中于 `onLayoutReady` **之前**调用，确保 Obsidian 恢复排序时按钮已存在。
- **`init()`** — 处理其余初始化（状态栏、命令等），仍在 `onLayoutReady` 内调用，行为不变。

## Changes / 改动文件

- `src/lib/menu_manager.ts`: extract ribbon creation into new `initRibbon()` method
- `src/main.ts`: instantiate `MenuManager` and call `initRibbon()` before `onLayoutReady`; use a `menuManagerInitialized` boolean guard instead of the previous `if (this.menuManager)` check

---

- `src/lib/menu_manager.ts`：新增 `initRibbon()` 方法，从 `init()` 中提取 ribbon 按钮创建逻辑
- `src/main.ts`：在 `onLayoutReady` 之前实例化 `MenuManager` 并调用 `initRibbon()`；用 `menuManagerInitialized` 布尔标志替换原来的 `if (this.menuManager)` 防重复检查

🤖 Generated with [Claude Code](https://claude.com/claude-code)