### PR TITLE
feat:增强在文件传输过程中断（如断网、退出客户端等）的稳定性（尤其针对移动客户端影响很大）

### DIFF
--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -277,6 +277,8 @@ export default {
   "ui.log.action.FileDelete": "Attachment Delete",
   "ui.log.action.FileRenameAck": "Attachment Rename Successful",
   "ui.log.action.FileUploadAck": "Attachment Upload Successful",
+  "ui.log.action.NoteModifyAck": "Note Modify Synced",
+  "ui.log.action.NoteRenameAck": "Note Rename Confirmed",
   "ui.log.action.NoteDeleteAck": "Note Delete Confirmed",
   "ui.log.action.FileDeleteAck": "Attachment Delete Confirmed",
   "ui.log.action.SettingSync_full": "Config Sync (Full)",

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -277,6 +277,8 @@ export default {
   "ui.log.action.FileDelete": "Attachment Delete",
   "ui.log.action.FileRenameAck": "Attachment Rename Successful",
   "ui.log.action.FileUploadAck": "Attachment Upload Successful",
+  "ui.log.action.NoteDeleteAck": "Note Delete Confirmed",
+  "ui.log.action.FileDeleteAck": "Attachment Delete Confirmed",
   "ui.log.action.SettingSync_full": "Config Sync (Full)",
   "ui.log.action.SettingSync_incremental": "Config Sync (Incremental)",
   "ui.log.action.SettingSyncModify": "Config Sync Update",

--- a/src/i18n/locales/ja.ts
+++ b/src/i18n/locales/ja.ts
@@ -277,6 +277,8 @@ export default {
   "ui.log.action.FileDelete": "添付ファイル削除",
   "ui.log.action.FileRenameAck": "添付ファイルリネーム成功",
   "ui.log.action.FileUploadAck": "添付ファイルアップロード成功",
+  "ui.log.action.NoteModifyAck": "ノート変更同期済み",
+  "ui.log.action.NoteRenameAck": "ノートリネーム確認済み",
   "ui.log.action.NoteDeleteAck": "ノート削除確認済み",
   "ui.log.action.FileDeleteAck": "添付ファイル削除確認済み",
   "ui.log.action.SettingSync_full": "設定同期（完全）",

--- a/src/i18n/locales/ja.ts
+++ b/src/i18n/locales/ja.ts
@@ -277,6 +277,8 @@ export default {
   "ui.log.action.FileDelete": "添付ファイル削除",
   "ui.log.action.FileRenameAck": "添付ファイルリネーム成功",
   "ui.log.action.FileUploadAck": "添付ファイルアップロード成功",
+  "ui.log.action.NoteDeleteAck": "ノート削除確認済み",
+  "ui.log.action.FileDeleteAck": "添付ファイル削除確認済み",
   "ui.log.action.SettingSync_full": "設定同期（完全）",
   "ui.log.action.SettingSync_incremental": "設定同期（増分）",
   "ui.log.action.SettingSyncModify": "設定同期更新",

--- a/src/i18n/locales/ko.ts
+++ b/src/i18n/locales/ko.ts
@@ -277,6 +277,8 @@ export default {
   "ui.log.action.FileDelete": "첨부 파일 삭제",
   "ui.log.action.FileRenameAck": "첨부 파일 이름 변경 성공",
   "ui.log.action.FileUploadAck": "첨부 파일 업로드 성공",
+  "ui.log.action.NoteModifyAck": "노트 수정 동기화됨",
+  "ui.log.action.NoteRenameAck": "노트 이름 변경 확인됨",
   "ui.log.action.NoteDeleteAck": "노트 삭제 확인됨",
   "ui.log.action.FileDeleteAck": "첨부 파일 삭제 확인됨",
   "ui.log.action.SettingSync_full": "설정 동기화(전체)",

--- a/src/i18n/locales/ko.ts
+++ b/src/i18n/locales/ko.ts
@@ -277,6 +277,8 @@ export default {
   "ui.log.action.FileDelete": "첨부 파일 삭제",
   "ui.log.action.FileRenameAck": "첨부 파일 이름 변경 성공",
   "ui.log.action.FileUploadAck": "첨부 파일 업로드 성공",
+  "ui.log.action.NoteDeleteAck": "노트 삭제 확인됨",
+  "ui.log.action.FileDeleteAck": "첨부 파일 삭제 확인됨",
   "ui.log.action.SettingSync_full": "설정 동기화(전체)",
   "ui.log.action.SettingSync_incremental": "설정 동기화(증분)",
   "ui.log.action.SettingSyncModify": "설정 동기화 업데이트",

--- a/src/i18n/locales/zh-CN.ts
+++ b/src/i18n/locales/zh-CN.ts
@@ -277,6 +277,8 @@ export default {
   "ui.log.action.FileDelete": "附件删除",
   "ui.log.action.FileRenameAck": "附件重命名成功",
   "ui.log.action.FileUploadAck": "附件上传成功",
+  "ui.log.action.NoteModifyAck": "笔记修改已同步",
+  "ui.log.action.NoteRenameAck": "笔记重命名已确认",
   "ui.log.action.NoteDeleteAck": "笔记删除已确认",
   "ui.log.action.FileDeleteAck": "附件删除已确认",
   "ui.log.action.SettingSync_full": "配置同步(全量)",

--- a/src/i18n/locales/zh-CN.ts
+++ b/src/i18n/locales/zh-CN.ts
@@ -277,6 +277,8 @@ export default {
   "ui.log.action.FileDelete": "附件删除",
   "ui.log.action.FileRenameAck": "附件重命名成功",
   "ui.log.action.FileUploadAck": "附件上传成功",
+  "ui.log.action.NoteDeleteAck": "笔记删除已确认",
+  "ui.log.action.FileDeleteAck": "附件删除已确认",
   "ui.log.action.SettingSync_full": "配置同步(全量)",
   "ui.log.action.SettingSync_incremental": "配置同步(增量)",
   "ui.log.action.SettingSyncModify": "配置同步更新",

--- a/src/i18n/locales/zh-TW.ts
+++ b/src/i18n/locales/zh-TW.ts
@@ -277,6 +277,8 @@ export default {
   "ui.log.action.FileDelete": "附件刪除",
   "ui.log.action.FileRenameAck": "附件重命名成功",
   "ui.log.action.FileUploadAck": "附件上傳成功",
+  "ui.log.action.NoteModifyAck": "筆記修改已同步",
+  "ui.log.action.NoteRenameAck": "筆記重命名已確認",
   "ui.log.action.NoteDeleteAck": "筆記刪除已確認",
   "ui.log.action.FileDeleteAck": "附件刪除已確認",
   "ui.log.action.SettingSync_full": "配置同步(全量)",

--- a/src/i18n/locales/zh-TW.ts
+++ b/src/i18n/locales/zh-TW.ts
@@ -277,6 +277,8 @@ export default {
   "ui.log.action.FileDelete": "附件刪除",
   "ui.log.action.FileRenameAck": "附件重命名成功",
   "ui.log.action.FileUploadAck": "附件上傳成功",
+  "ui.log.action.NoteDeleteAck": "筆記刪除已確認",
+  "ui.log.action.FileDeleteAck": "附件刪除已確認",
   "ui.log.action.SettingSync_full": "配置同步(全量)",
   "ui.log.action.SettingSync_incremental": "配置同步(增量)",
   "ui.log.action.SettingSyncModify": "配置同步更新",

--- a/src/lib/file_operator.ts
+++ b/src/lib/file_operator.ts
@@ -203,10 +203,10 @@ export const fileRename = async function (file: TAbstractFile, oldfile: string, 
           path: file.path,
           pathHash: hashContent(file.path),
         }
-        plugin.websocket.SendMessage("FileRename", data, undefined, () => {
-          plugin.fileHashManager.setFileHash(file.path, contentHash)
-          plugin.fileHashManager.removeFileHash(oldfile)
-        })
+        // 将重命名推入待确认队列，等待服务端 FileRenameAck 后再更新 hashManager
+        // Push rename to pending queue; hashManager will be updated after server FileRenameAck
+        plugin.pendingFileRenames.push({ oldPath: oldfile, newPath: file.path, contentHash })
+        plugin.websocket.SendMessage("FileRename", data)
       }
     } finally {
       plugin.removeIgnoredFile(file.path)
@@ -911,9 +911,16 @@ const handleFileChunkDownloadComplete = async function (session: FileDownloadSes
   }
 }
 
-// 收到 FileRenameAck，用服务端返回的时间戳更新 lastFileSyncTime
-// Receive FileRenameAck, update lastFileSyncTime with server-returned timestamp
+// 收到 FileRenameAck，服务端确认后更新 hashManager（FIFO 出队）并更新 lastFileSyncTime
+// Receive FileRenameAck, update hashManager after server confirmation (FIFO dequeue) and update lastFileSyncTime
 export const receiveFileRenameAck = function (data: { lastTime?: number }, plugin: FastSync) {
+  // 服务端确认重命名成功，FIFO 出队并更新 hashManager
+  // Server confirmed rename success, dequeue FIFO and update hashManager
+  const pending = plugin.pendingFileRenames.shift()
+  if (pending) {
+    plugin.fileHashManager.setFileHash(pending.newPath, pending.contentHash)
+    plugin.fileHashManager.removeFileHash(pending.oldPath)
+  }
   if (data.lastTime && data.lastTime > Number(plugin.localStorageManager.getMetadata("lastFileSyncTime"))) {
     plugin.localStorageManager.setMetadata("lastFileSyncTime", data.lastTime)
     dump(`FileRenameAck: lastFileSyncTime updated to`, data.lastTime)

--- a/src/lib/file_operator.ts
+++ b/src/lib/file_operator.ts
@@ -67,10 +67,10 @@ export const fileModify = async function (file: TAbstractFile, plugin: FastSync,
         // 始终传递 baseHash 信息，如果不可用则标记 baseHashMissing
         ...(baseHash !== null ? { baseHash } : { baseHashMissing: true }),
       }
-      plugin.websocket.SendMessage("FileUploadCheck", data, undefined, () => {
-        // WebSocket 消息发送后更新哈希表(使用内容哈希)
-        plugin.fileHashManager.setFileHash(file.path, contentHash)
-      })
+      // 将 hash 暂存到 pending map，等待服务端 FileUploadAck 后再写入 hashManager
+      // Temporarily store hash in pending map, update hashManager only after server FileUploadAck
+      plugin.pendingUploadHashes.set(file.path, contentHash)
+      plugin.websocket.SendMessage("FileUploadCheck", data)
       dump(`File modify check sent`, data.path, data.contentHash)
     } finally {
       plugin.removeIgnoredFile(file.path)
@@ -102,8 +102,13 @@ export const fileDelete = async function (file: TAbstractFile, plugin: FastSync,
       dump(`Upload cancelled due to file deletion: ${file.path}`);
       // 仅清理本地状态
       plugin.fileHashManager.removeFileHash(file.path)
+      plugin.pendingUploadHashes.delete(file.path)
       return
     }
+
+    // 清理可能存在的待确认上传记录，避免 pending map 内存泄漏
+    // Clean up any pending upload record to avoid pending map memory leak
+    plugin.pendingUploadHashes.delete(file.path)
 
     plugin.addIgnoredFile(file.path)
     try {
@@ -139,8 +144,13 @@ export const fileDeleteByPath = async function (filePath: string, plugin: FastSy
     if (activeUploadsMap.has(filePath)) {
       activeUploadsMap.get(filePath)!.cancelled = true;
       plugin.fileHashManager.removeFileHash(filePath)
+      plugin.pendingUploadHashes.delete(filePath)
       return
     }
+
+    // 清理可能存在的待确认上传记录，避免 pending map 内存泄漏
+    // Clean up any pending upload record to avoid pending map memory leak
+    plugin.pendingUploadHashes.delete(filePath)
 
     plugin.addIgnoredFile(filePath)
     try {
@@ -927,9 +937,18 @@ export const receiveFileRenameAck = function (data: { lastTime?: number }, plugi
   }
 }
 
-// 收到 FileUploadAck，用服务端返回的时间戳更新 lastFileSyncTime
-// Receive FileUploadAck, update lastFileSyncTime with server-returned timestamp
-export const receiveFileUploadAck = function (data: { lastTime?: number }, plugin: FastSync) {
+// 收到 FileUploadAck，将 pending hash 转移到正式 hashManager 并更新 lastFileSyncTime
+// Receive FileUploadAck, move pending hash to formal hashManager and update lastFileSyncTime
+export const receiveFileUploadAck = function (data: { lastTime?: number; path?: string }, plugin: FastSync) {
+  // 服务端确认上传成功，将 pending hash 转移到正式 hashManager
+  // Server confirmed upload success, move pending hash to formal hashManager
+  if (data.path) {
+    const contentHash = plugin.pendingUploadHashes.get(data.path)
+    if (contentHash !== undefined) {
+      plugin.fileHashManager.setFileHash(data.path, contentHash)
+      plugin.pendingUploadHashes.delete(data.path)
+    }
+  }
   if (data.lastTime && data.lastTime > Number(plugin.localStorageManager.getMetadata("lastFileSyncTime"))) {
     plugin.localStorageManager.setMetadata("lastFileSyncTime", data.lastTime)
     dump(`FileUploadAck: lastFileSyncTime updated to`, data.lastTime)

--- a/src/lib/file_operator.ts
+++ b/src/lib/file_operator.ts
@@ -69,6 +69,9 @@ export const fileModify = async function (file: TAbstractFile, plugin: FastSync,
       }
       // 将 hash 暂存到 pending map，等待服务端 FileUploadAck 后再写入 hashManager
       // Temporarily store hash in pending map, update hashManager only after server FileUploadAck
+      // 新建操作覆盖删除意图，清除 pending 防止晚到的 Ack 错误删除新文件 hash
+      // New upload supersedes delete intent; clear pending to prevent stale Ack from removing new hash
+      plugin.pendingFileDeleteAcks.delete(file.path)
       plugin.pendingUploadHashes.set(file.path, contentHash)
       plugin.websocket.SendMessage("FileUploadCheck", data)
       dump(`File modify check sent`, data.path, data.contentHash)
@@ -118,8 +121,9 @@ export const fileDelete = async function (file: TAbstractFile, plugin: FastSync,
         pathHash: hashContent(file.path),
       }
       plugin.websocket.SendMessage("FileDelete", data, undefined, () => {
-        // WebSocket 消息发送后从哈希表中删除
-        plugin.fileHashManager.removeFileHash(file.path)
+        // 消息真正写入 TCP 缓冲区后加入 pending set，等待 FileDeleteAck 再删 hash
+        // Add to pending set only after message is actually buffered; remove hash only on FileDeleteAck
+        plugin.pendingFileDeleteAcks.add(file.path)
       })
       dump(`File delete send`, file.path)
     } finally {
@@ -159,9 +163,9 @@ export const fileDeleteByPath = async function (filePath: string, plugin: FastSy
         path: filePath,
         pathHash: hashContent(filePath),
       }, undefined, () => {
-        // WebSocket 消息发送后从哈希表中删除
-        // Remove from hash map after sending WebSocket message
-        plugin.fileHashManager.removeFileHash(filePath)
+        // 消息真正写入 TCP 缓冲区后加入 pending set，等待 FileDeleteAck 再删 hash
+        // Add to pending set only after message is actually buffered; remove hash only on FileDeleteAck
+        plugin.pendingFileDeleteAcks.add(filePath)
       })
       dump(`File delete by path send`, filePath)
     } finally {
@@ -415,6 +419,9 @@ export const receiveFileUpload = async function (data: FileUploadMessage, plugin
  */
 export const receiveFileSyncUpdate = async function (data: ReceiveFileSyncUpdateMessage, plugin: FastSync) {
   if (plugin.settings.syncEnabled == false) return
+  // 服务端推送说明该路径已有新内容，清除可能残留的 deleteAck pending 防止 Ack 删除新 hash
+  // Server push means path has new content; clear stale deleteAck pending to protect newly-written hash
+  plugin.pendingFileDeleteAcks.delete(data.path)
   if (isPathExcluded(data.path, plugin)) {
     plugin.fileSyncTasks.completed++;
     return
@@ -952,6 +959,18 @@ export const receiveFileUploadAck = function (data: { lastTime?: number; path?: 
   if (data.lastTime && data.lastTime > Number(plugin.localStorageManager.getMetadata("lastFileSyncTime"))) {
     plugin.localStorageManager.setMetadata("lastFileSyncTime", data.lastTime)
     dump(`FileUploadAck: lastFileSyncTime updated to`, data.lastTime)
+  }
+}
+
+// 收到 FileDeleteAck，仅当路径仍在 pending set 中时才从 hashManager 移除
+// Receive FileDeleteAck; only remove from hashManager if path is still pending
+export const receiveFileDeleteAck = function (data: { lastTime?: number; path?: string }, plugin: FastSync) {
+  if (data.path && plugin.pendingFileDeleteAcks.has(data.path)) {
+    plugin.fileHashManager.removeFileHash(data.path)
+    plugin.pendingFileDeleteAcks.delete(data.path)
+  }
+  if (data.lastTime && data.lastTime > Number(plugin.localStorageManager.getMetadata("lastFileSyncTime"))) {
+    plugin.localStorageManager.setMetadata("lastFileSyncTime", data.lastTime)
   }
 }
 

--- a/src/lib/note_operator.ts
+++ b/src/lib/note_operator.ts
@@ -216,6 +216,9 @@ export const receiveNoteSyncModify = async function (data: ReceiveMessage, plugi
       plugin.fileHashManager.setFileHash(data.path, data.contentHash)
       // 记录同步后的 mtime 用于拦截
       plugin.lastSyncMtime.set(data.path, data.mtime)
+      // 服务端版本已覆盖本地，清理 pending 避免增量过滤器旁路导致该笔记无限重传
+      // Server version overrides local; clear pending to avoid incremental filter bypass loop
+      plugin.pendingNoteModifies.delete(data.path)
     } finally {
       setTimeout(() => {
         plugin.removeIgnoredFile(normalizedPath)
@@ -272,8 +275,12 @@ export const receiveNoteUpload = async function (data: ReceivePathMessage, plugi
     // 始终传递 baseHash 信息，如果不可用则标记 baseHashMissing
     ...(baseHash !== null ? { baseHash } : { baseHashMissing: true }),
   }
+  // 将 hash 写入 pending map，等待 NoteModifyAck 确认后再写 hashManager
+  // 若此路径已有旧 pending（来自中断的 noteModify），覆盖为最新 hash
+  // Store hash in pending map; hashManager is written only after NoteModifyAck arrives.
+  // Overwrites any stale pending entry left by a previously interrupted noteModify.
+  plugin.pendingNoteModifies.set(file.path, contentHash)
   plugin.websocket.SendMessage("NoteModify", sendData, undefined, () => {
-    plugin.fileHashManager.setFileHash(file.path, contentHash)
     plugin.removeIgnoredFile(file.path)
     plugin.noteSyncTasks.completed++
   })
@@ -302,6 +309,13 @@ export const receiveNoteSyncMtime = async function (data: ReceiveMtimeMessage, p
         await plugin.app.vault.modify(file, content, { ...(data.ctime > 0 && { ctime: data.ctime }), ...(data.mtime > 0 && { mtime: data.mtime }) })
         // 记录 mtime
         plugin.lastSyncMtime.set(data.path, data.mtime)
+        // 服务端走 UpdateMtime 说明内容 hash 与客户端发送的一致，提交 pending hash 到 hashManager
+        // Server UpdateMtime means content hash matches what client sent; commit pending hash to hashManager
+        const pendingHash = plugin.pendingNoteModifies.get(data.path)
+        if (pendingHash !== undefined) {
+          plugin.fileHashManager.setFileHash(data.path, pendingHash)
+          plugin.pendingNoteModifies.delete(data.path)
+        }
         // 更新同步时间
         if (data.lastTime && data.lastTime > Number(plugin.localStorageManager.getMetadata("lastNoteSyncTime"))) {
           plugin.localStorageManager.setMetadata("lastNoteSyncTime", data.lastTime)
@@ -338,6 +352,9 @@ export const receiveNoteSyncDelete = async function (data: ReceiveMessage, plugi
         // 服务端推送删除,从哈希表中移除
         plugin.fileHashManager.removeFileHash(normalizedPath)
         plugin.lastSyncMtime.delete(normalizedPath)
+        // 清理 pending，避免已删除路径的 pending 条目泄漏
+        // Clean up pending to prevent memory leak for deleted path
+        plugin.pendingNoteModifies.delete(normalizedPath)
         // 更新同步时间
         if (data.lastTime && data.lastTime > Number(plugin.localStorageManager.getMetadata("lastNoteSyncTime"))) {
           plugin.localStorageManager.setMetadata("lastNoteSyncTime", data.lastTime)
@@ -465,6 +482,8 @@ export const receiveNoteModifyAck = function (data: { lastTime?: number; path?: 
     if (contentHash !== undefined) {
       plugin.fileHashManager.setFileHash(data.path, contentHash)
       plugin.pendingNoteModifies.delete(data.path)
+    } else {
+      dump(`NoteModifyAck received for non-pending path: ${data.path}`)
     }
   }
   if (data.lastTime && data.lastTime > Number(plugin.localStorageManager.getMetadata("lastNoteSyncTime"))) {

--- a/src/lib/note_operator.ts
+++ b/src/lib/note_operator.ts
@@ -45,6 +45,9 @@ export const noteModify = async function (file: TAbstractFile, plugin: FastSync,
       // 将 hash 暂存到 pending map，等待服务端 NoteModifyAck 后再写入 hashManager
       // Temporarily store hash in pending map, update hashManager only after server NoteModifyAck
       if (contentHash != baseHash) {
+        // 新建操作覆盖删除意图，清除 pending 防止晚到的 Ack 错误删除新文件 hash
+        // New create supersedes delete intent; clear pending to prevent stale Ack from removing new hash
+        plugin.pendingNoteDeleteAcks.delete(file.path)
         plugin.pendingNoteModifies.set(file.path, contentHash)
       }
       plugin.websocket.SendMessage("NoteModify", data)
@@ -84,8 +87,9 @@ export const noteDelete = async function (file: TAbstractFile, plugin: FastSync,
         pathHash: hashContent(file.path),
       }
       plugin.websocket.SendMessage("NoteDelete", data, undefined, () => {
-        // WebSocket 消息发送后从哈希表中删除
-        plugin.fileHashManager.removeFileHash(file.path)
+        // 消息真正写入 TCP 缓冲区后加入 pending set，等待 NoteDeleteAck 再删 hash
+        // Add to pending set only after message is actually buffered; remove hash only on NoteDeleteAck
+        plugin.pendingNoteDeleteAcks.add(file.path)
       })
 
       dump(`Note delete send`, file.path)
@@ -116,9 +120,9 @@ export const noteDeleteByPath = async function (filePath: string, plugin: FastSy
         path: filePath,
         pathHash: hashContent(filePath),
       }, undefined, () => {
-        // WebSocket 消息发送后从哈希表中删除
-        // Remove from hash map after sending WebSocket message
-        plugin.fileHashManager.removeFileHash(filePath)
+        // 消息真正写入 TCP 缓冲区后加入 pending set，等待 NoteDeleteAck 再删 hash
+        // Add to pending set only after message is actually buffered; remove hash only on NoteDeleteAck
+        plugin.pendingNoteDeleteAcks.add(filePath)
       })
       dump(`Note delete by path send`, filePath)
     } finally {
@@ -219,6 +223,9 @@ export const receiveNoteSyncModify = async function (data: ReceiveMessage, plugi
       // 服务端版本已覆盖本地，清理 pending 避免增量过滤器旁路导致该笔记无限重传
       // Server version overrides local; clear pending to avoid incremental filter bypass loop
       plugin.pendingNoteModifies.delete(data.path)
+      // 服务端推送新内容说明该路径已被创建/更新，清理可能残留的 deleteAck pending
+      // Server push means path was created/updated; clear any stale deleteAck pending
+      plugin.pendingNoteDeleteAcks.delete(data.path)
     } finally {
       setTimeout(() => {
         plugin.removeIgnoredFile(normalizedPath)
@@ -500,6 +507,18 @@ export const receiveNoteRenameAck = function (data: { lastTime?: number }, plugi
   if (pending) {
     plugin.fileHashManager.removeFileHash(pending.oldPath)
     plugin.fileHashManager.setFileHash(pending.newPath, pending.contentHash)
+  }
+  if (data.lastTime && data.lastTime > Number(plugin.localStorageManager.getMetadata("lastNoteSyncTime"))) {
+    plugin.localStorageManager.setMetadata("lastNoteSyncTime", data.lastTime)
+  }
+}
+
+// 收到 NoteDeleteAck，仅当路径仍在 pending set 中时才从 hashManager 移除
+// Receive NoteDeleteAck; only remove from hashManager if path is still pending
+export const receiveNoteDeleteAck = function (data: { lastTime?: number; path?: string }, plugin: FastSync) {
+  if (data.path && plugin.pendingNoteDeleteAcks.has(data.path)) {
+    plugin.fileHashManager.removeFileHash(data.path)
+    plugin.pendingNoteDeleteAcks.delete(data.path)
   }
   if (data.lastTime && data.lastTime > Number(plugin.localStorageManager.getMetadata("lastNoteSyncTime"))) {
     plugin.localStorageManager.setMetadata("lastNoteSyncTime", data.lastTime)

--- a/src/lib/note_operator.ts
+++ b/src/lib/note_operator.ts
@@ -42,12 +42,12 @@ export const noteModify = async function (file: TAbstractFile, plugin: FastSync,
         // 始终传递 baseHash 信息，如果不可用则标记 baseHashMissing
         ...(baseHash !== null ? { baseHash } : { baseHashMissing: true }),
       }
-      plugin.websocket.SendMessage("NoteModify", data, undefined, () => {
-        // WebSocket 消息发送后更新哈希表(使用内容哈希)
-        if (contentHash != baseHash) {
-          plugin.fileHashManager.setFileHash(file.path, contentHash)
-        }
-      })
+      // 将 hash 暂存到 pending map，等待服务端 NoteModifyAck 后再写入 hashManager
+      // Temporarily store hash in pending map, update hashManager only after server NoteModifyAck
+      if (contentHash != baseHash) {
+        plugin.pendingNoteModifies.set(file.path, contentHash)
+      }
+      plugin.websocket.SendMessage("NoteModify", data)
       dump(`Note modify send`, data.path, data.contentHash, data.mtime, data.pathHash)
     } finally {
       plugin.removeIgnoredFile(file.path)
@@ -73,6 +73,9 @@ export const noteDelete = async function (file: TAbstractFile, plugin: FastSync,
   }
 
   await plugin.lockManager.withLock(file.path, async () => {
+    // 清理可能存在的待确认上传记录，避免 pending map 内存泄漏
+    // Clean up any pending note modify record to avoid memory leak
+    plugin.pendingNoteModifies.delete(file.path)
     plugin.addIgnoredFile(file.path)
     try {
       const data = {
@@ -103,6 +106,9 @@ export const noteDeleteByPath = async function (filePath: string, plugin: FastSy
   if (plugin.lastSyncPathDeleted.has(filePath)) return
 
   await plugin.lockManager.withLock(filePath, async () => {
+    // 清理可能存在的待确认上传记录，避免 pending map 内存泄漏
+    // Clean up any pending note modify record to avoid memory leak
+    plugin.pendingNoteModifies.delete(filePath)
     plugin.addIgnoredFile(filePath)
     try {
       plugin.websocket.SendMessage("NoteDelete", {
@@ -156,11 +162,10 @@ export const noteRename = async function (file: TAbstractFile, oldfile: string, 
         oldPathHash: hashContent(oldfile),
       }
 
-      plugin.websocket.SendMessage("NoteRename", data, undefined, () => {
-        // 删除旧路径,添加新路径(使用内容哈希)
-        plugin.fileHashManager.removeFileHash(oldfile)
-        plugin.fileHashManager.setFileHash(file.path, contentHash)
-      })
+      // 将重命名信息推入 FIFO 队列，等待服务端 NoteRenameAck 后再更新 hashManager
+      // Push rename info to FIFO queue, update hashManager only after server NoteRenameAck
+      plugin.pendingNoteRenames.push({ oldPath: oldfile, newPath: file.path, contentHash })
+      plugin.websocket.SendMessage("NoteRename", data)
       dump(`Note rename send`, data.path, data.pathHash)
     } finally {
       plugin.removeIgnoredFile(file.path)
@@ -448,4 +453,36 @@ export const receiveNoteSyncRename = async function (data: any, plugin: FastSync
   }, { maxRetries: 10, retryInterval: 100 });
 
   plugin.noteSyncTasks.completed++
+}
+
+// 收到 NoteModifyAck，将 pending hash 转移到正式 hashManager 并更新 lastNoteSyncTime
+// Receive NoteModifyAck, move pending hash to formal hashManager and update lastNoteSyncTime
+export const receiveNoteModifyAck = function (data: { lastTime?: number; path?: string }, plugin: FastSync) {
+  // 服务端确认笔记写入成功，将 pending hash 转移到正式 hashManager
+  // Server confirmed note write success, move pending hash to formal hashManager
+  if (data.path) {
+    const contentHash = plugin.pendingNoteModifies.get(data.path)
+    if (contentHash !== undefined) {
+      plugin.fileHashManager.setFileHash(data.path, contentHash)
+      plugin.pendingNoteModifies.delete(data.path)
+    }
+  }
+  if (data.lastTime && data.lastTime > Number(plugin.localStorageManager.getMetadata("lastNoteSyncTime"))) {
+    plugin.localStorageManager.setMetadata("lastNoteSyncTime", data.lastTime)
+  }
+}
+
+// 收到 NoteRenameAck，从 FIFO 队列取出待确认条目并更新 hashManager
+// Receive NoteRenameAck, shift from FIFO queue and update hashManager
+export const receiveNoteRenameAck = function (data: { lastTime?: number }, plugin: FastSync) {
+  // TCP 保证有序，FIFO 匹配正确
+  // TCP guarantees ordering, FIFO matching is correct
+  const pending = plugin.pendingNoteRenames.shift()
+  if (pending) {
+    plugin.fileHashManager.removeFileHash(pending.oldPath)
+    plugin.fileHashManager.setFileHash(pending.newPath, pending.contentHash)
+  }
+  if (data.lastTime && data.lastTime > Number(plugin.localStorageManager.getMetadata("lastNoteSyncTime"))) {
+    plugin.localStorageManager.setMetadata("lastNoteSyncTime", data.lastTime)
+  }
 }

--- a/src/lib/operator.ts
+++ b/src/lib/operator.ts
@@ -397,8 +397,12 @@ export const handleSync = async function (plugin: FastSync, isLoadLastTime: bool
           const skipSync = plugin.settings.cloudPreviewEnabled && (!plugin.settings.cloudPreviewTypeRestricted || FileCloudPreview.isRestrictedType("." + file.extension));
           if (skipSync) continue;
 
-          // 优化增量同步过滤：仅在文件已追踪且 mtime 未超过上次同步时间时跳过
-          if (isLoadLastTime && file.stat.mtime < Number(plugin.localStorageManager.getMetadata("lastFileSyncTime")) && plugin.fileHashManager.getPathHash(file.path) !== null) continue;
+          // 优化增量同步过滤：仅在文件已追踪、mtime 未超过上次同步时间且无待确认上传时跳过
+          // Skip only if file is tracked, mtime not newer than last sync time, and no pending upload
+          if (isLoadLastTime
+            && file.stat.mtime < Number(plugin.localStorageManager.getMetadata("lastFileSyncTime"))
+            && plugin.fileHashManager.getPathHash(file.path) !== null
+            && !plugin.pendingUploadHashes.has(file.path)) continue;
           const contentHash = await hashArrayBuffer(await plugin.app.vault.readBinary(file));
           const baseHash = plugin.fileHashManager.getPathHash(file.path);
           let item = {

--- a/src/lib/operator.ts
+++ b/src/lib/operator.ts
@@ -310,6 +310,9 @@ export const handleSync = async function (plugin: FastSync, isLoadLastTime: bool
   plugin.downloadedChunksCount = 0;
   plugin.totalChunksToUpload = 0;
   plugin.uploadedChunksCount = 0;
+  // 清空上一次连接的未完成 rename 队列，由 hashManager 旧路径进 delFiles 自然处理
+  // Clear pending renames from previous connection; old paths in hashManager will naturally go into delFiles
+  plugin.pendingFileRenames = []
   plugin.disableWatch();
 
   if (plugin.settings.isShowNotice && (plugin.settings.syncEnabled || plugin.settings.configSyncEnabled)) {

--- a/src/lib/operator.ts
+++ b/src/lib/operator.ts
@@ -1,8 +1,8 @@
 import { TFolder, TFile, Notice, normalizePath, Platform } from "obsidian";
 
-import { receiveFileUpload, receiveFileSyncUpdate, receiveFileSyncDelete, receiveFileSyncMtime, receiveFileSyncChunkDownload, receiveFileSyncEnd, checkAndUploadAttachments, receiveFileSyncRename, receiveFileRenameAck, receiveFileUploadAck } from "./file_operator";
+import { receiveFileUpload, receiveFileSyncUpdate, receiveFileSyncDelete, receiveFileSyncMtime, receiveFileSyncChunkDownload, receiveFileSyncEnd, checkAndUploadAttachments, receiveFileSyncRename, receiveFileRenameAck, receiveFileUploadAck, receiveFileDeleteAck } from "./file_operator";
 import { receiveConfigSyncModify, receiveConfigUpload, receiveConfigSyncMtime, receiveConfigSyncDelete, receiveConfigSyncEnd, configAllPaths, receiveConfigSyncClear } from "./config_operator";
-import { receiveNoteSyncModify, receiveNoteUpload, receiveNoteSyncMtime, receiveNoteSyncDelete, receiveNoteSyncEnd, receiveNoteSyncRename, receiveNoteModifyAck, receiveNoteRenameAck } from "./note_operator";
+import { receiveNoteSyncModify, receiveNoteUpload, receiveNoteSyncMtime, receiveNoteSyncDelete, receiveNoteSyncEnd, receiveNoteSyncRename, receiveNoteModifyAck, receiveNoteRenameAck, receiveNoteDeleteAck } from "./note_operator";
 import { SyncMode, SnapFile, SnapFolder, SyncEndData, PathHashFile, NoteSyncData, FileSyncData, ConfigSyncData, FolderSyncData } from "./types";
 import { receiveFolderSyncModify, receiveFolderSyncDelete, receiveFolderSyncRename, receiveFolderSyncEnd } from "./folder_operator";
 import { hashContent, hashArrayBuffer, dump, isPathExcluded, configIsPathExcluded, getConfigSyncCustomDirs, generateUUID, showSyncNotice } from "./helps";
@@ -204,6 +204,7 @@ export const receiveOperators: Map<string, ReceiveOperator> = new Map([
   ["NoteSyncRename", receiveNoteSyncRename],
   ["NoteModifyAck", (data, plugin) => receiveNoteModifyAck(data, plugin)],
   ["NoteRenameAck", (data, plugin) => receiveNoteRenameAck(data, plugin)],
+  ["NoteDeleteAck", (data, plugin) => receiveNoteDeleteAck(data, plugin)],
   ["NoteSyncEnd", (data, plugin) => receiveSyncEndWrapper(data, plugin, "note")],
   ["FileUpload", receiveFileUpload],
   ["FileSyncUpdate", receiveFileSyncUpdate],
@@ -214,6 +215,7 @@ export const receiveOperators: Map<string, ReceiveOperator> = new Map([
   ["FileSyncEnd", (data, plugin) => receiveSyncEndWrapper(data, plugin, "file")],
   ["FileRenameAck", receiveFileRenameAck],
   ["FileUploadAck", receiveFileUploadAck],
+  ["FileDeleteAck", (data, plugin) => receiveFileDeleteAck(data, plugin)],
   ["SettingSyncModify", receiveConfigSyncModify],
   ["SettingSyncNeedUpload", receiveConfigUpload],
   ["SettingSyncMtime", receiveConfigSyncMtime],
@@ -342,6 +344,10 @@ export const handleSync = async function (plugin: FastSync, isLoadLastTime: bool
   plugin.pendingDeleteFilePaths.clear()
   plugin.pendingDeleteFolderPaths.clear()
   plugin.pendingDeleteConfigPaths.clear()
+  // 重连时清空 pending Ack 集合；路径保留在 hashManager，将自然进入 delNotes
+  // On reconnect clear pending Ack sets; paths remain in hashManager and flow into delNotes naturally
+  plugin.pendingNoteDeleteAcks.clear()
+  plugin.pendingFileDeleteAcks.clear()
   plugin.disableWatch();
 
   if (plugin.settings.isShowNotice && (plugin.settings.syncEnabled || plugin.settings.configSyncEnabled)) {

--- a/src/lib/operator.ts
+++ b/src/lib/operator.ts
@@ -2,7 +2,7 @@ import { TFolder, TFile, Notice, normalizePath, Platform } from "obsidian";
 
 import { receiveFileUpload, receiveFileSyncUpdate, receiveFileSyncDelete, receiveFileSyncMtime, receiveFileSyncChunkDownload, receiveFileSyncEnd, checkAndUploadAttachments, receiveFileSyncRename, receiveFileRenameAck, receiveFileUploadAck } from "./file_operator";
 import { receiveConfigSyncModify, receiveConfigUpload, receiveConfigSyncMtime, receiveConfigSyncDelete, receiveConfigSyncEnd, configAllPaths, receiveConfigSyncClear } from "./config_operator";
-import { receiveNoteSyncModify, receiveNoteUpload, receiveNoteSyncMtime, receiveNoteSyncDelete, receiveNoteSyncEnd, receiveNoteSyncRename } from "./note_operator";
+import { receiveNoteSyncModify, receiveNoteUpload, receiveNoteSyncMtime, receiveNoteSyncDelete, receiveNoteSyncEnd, receiveNoteSyncRename, receiveNoteModifyAck, receiveNoteRenameAck } from "./note_operator";
 import { SyncMode, SnapFile, SnapFolder, SyncEndData, PathHashFile, NoteSyncData, FileSyncData, ConfigSyncData, FolderSyncData } from "./types";
 import { receiveFolderSyncModify, receiveFolderSyncDelete, receiveFolderSyncRename, receiveFolderSyncEnd } from "./folder_operator";
 import { hashContent, hashArrayBuffer, dump, isPathExcluded, configIsPathExcluded, getConfigSyncCustomDirs, generateUUID, showSyncNotice } from "./helps";
@@ -202,6 +202,8 @@ export const receiveOperators: Map<string, ReceiveOperator> = new Map([
   ["NoteSyncMtime", receiveNoteSyncMtime],
   ["NoteSyncDelete", receiveNoteSyncDelete],
   ["NoteSyncRename", receiveNoteSyncRename],
+  ["NoteModifyAck", (data, plugin) => receiveNoteModifyAck(data, plugin)],
+  ["NoteRenameAck", (data, plugin) => receiveNoteRenameAck(data, plugin)],
   ["NoteSyncEnd", (data, plugin) => receiveSyncEndWrapper(data, plugin, "note")],
   ["FileUpload", receiveFileUpload],
   ["FileSyncUpdate", receiveFileSyncUpdate],
@@ -250,6 +252,24 @@ async function receiveSyncEndWrapper(data: any, plugin: FastSync, type: "note" |
 
   // 1.1 注意：v1.1 协议中 End 消息不再携带 messages 列表。
   // 排除项的处理将依赖于后端是否推送相关通知。
+
+  // 2. SyncEnd 到达说明服务端已处理本轮同步（含删除），将 pending 删除路径从 hashManager 移除
+  // SyncEnd means server processed this sync round (including deletes); remove pending delete paths from hashManager
+  if (type === "note") {
+    for (const path of plugin.pendingDeleteNotePaths) plugin.fileHashManager.removeFileHash(path)
+    plugin.pendingDeleteNotePaths.clear()
+  } else if (type === "file") {
+    for (const path of plugin.pendingDeleteFilePaths) plugin.fileHashManager.removeFileHash(path)
+    plugin.pendingDeleteFilePaths.clear()
+  } else if (type === "folder") {
+    for (const path of plugin.pendingDeleteFolderPaths) plugin.folderSnapshotManager.removeFolder(path)
+    plugin.pendingDeleteFolderPaths.clear()
+  } else if (type === "config") {
+    if (plugin.configHashManager && plugin.configHashManager.isReady()) {
+      for (const path of plugin.pendingDeleteConfigPaths) plugin.configHashManager.removeFileHash(path)
+    }
+    plugin.pendingDeleteConfigPaths.clear()
+  }
 
   // 3. 调用原始 End 处理函数 (更新时间戳等)
   if (type === "note") {
@@ -313,6 +333,15 @@ export const handleSync = async function (plugin: FastSync, isLoadLastTime: bool
   // 清空上一次连接的未完成 rename 队列，由 hashManager 旧路径进 delFiles 自然处理
   // Clear pending renames from previous connection; old paths in hashManager will naturally go into delFiles
   plugin.pendingFileRenames = []
+  // 清空上一次连接的未完成笔记 rename 队列，由 hashManager 旧路径进 delNotes 自然处理
+  // Clear pending note renames from previous connection; old paths in hashManager will naturally go into delNotes
+  plugin.pendingNoteRenames = []
+  // 清空 pending 删除路径集合，避免旧的 pending 条目干扰本次同步
+  // Clear pending delete path sets to avoid stale entries interfering with this sync
+  plugin.pendingDeleteNotePaths.clear()
+  plugin.pendingDeleteFilePaths.clear()
+  plugin.pendingDeleteFolderPaths.clear()
+  plugin.pendingDeleteConfigPaths.clear()
   plugin.disableWatch();
 
   if (plugin.settings.isShowNotice && (plugin.settings.syncEnabled || plugin.settings.configSyncEnabled)) {
@@ -377,8 +406,12 @@ export const handleSync = async function (plugin: FastSync, isLoadLastTime: bool
 
       if (file instanceof TFile) {
         if (file.extension === "md") {
-          // 优化增量同步过滤：仅在文件已追踪且 mtime 未超过上次同步时间时跳过
-          if (isLoadLastTime && file.stat.mtime < Number(plugin.localStorageManager.getMetadata("lastNoteSyncTime")) && plugin.fileHashManager.getPathHash(file.path) !== null) continue;
+          // 优化增量同步过滤：仅在文件已追踪且 mtime 未超过上次同步时间，且无待确认上传时跳过
+          // Skip only if file is tracked, mtime not newer than last sync time, and no pending note modify
+          if (isLoadLastTime
+            && file.stat.mtime < Number(plugin.localStorageManager.getMetadata("lastNoteSyncTime"))
+            && plugin.fileHashManager.getPathHash(file.path) !== null
+            && !plugin.pendingNoteModifies.has(file.path)) continue;
           const contentHash = hashContent(await plugin.app.vault.cachedRead(file));
           const baseHash = plugin.fileHashManager.getPathHash(file.path);
           let item = {
@@ -665,11 +698,12 @@ export const handleRequestSend = async function (plugin: FastSync, syncMode: Syn
       plugin.websocket.SendMessage("FileSync", fileSyncData);
     }
 
-    // 清理已删除文件的本地哈希数据,防止重复检测
+    // 将已删除路径加入 pending set，等待 SyncEnd 确认服务端已处理后再从 hashManager 移除
+    // Populate pending delete sets; remove from hashManager only after SyncEnd confirms server processed
     if (plugin.settings.offlineDeleteSyncEnabled) {
-      for (const item of noteData.delNotes) plugin.fileHashManager.removeFileHash(item.path);
-      for (const item of fileData.delFiles) plugin.fileHashManager.removeFileHash(item.path);
-      for (const item of folderData.delFolders) plugin.folderSnapshotManager.removeFolder(item.path);
+      plugin.pendingDeleteNotePaths = new Set(noteData.delNotes.map(i => i.path))
+      plugin.pendingDeleteFilePaths = new Set(fileData.delFiles.map(i => i.path))
+      plugin.pendingDeleteFolderPaths = new Set(folderData.delFolders.map(i => i.path))
     }
   }
 
@@ -689,9 +723,10 @@ export const handleRequestSend = async function (plugin: FastSync, syncMode: Syn
       }
     });
 
-    // 清理已删除配置的本地哈希数据,防止重复检测
+    // 将已删除配置路径加入 pending set，等待 SettingSyncEnd 确认服务端已处理后再移除
+    // Populate pending config delete set; remove from hashManager only after SettingSyncEnd
     if (plugin.settings.offlineDeleteSyncEnabled && plugin.configHashManager && plugin.configHashManager.isReady()) {
-      for (const item of configData.delConfigs) plugin.configHashManager.removeFileHash(item.path);
+      plugin.pendingDeleteConfigPaths = new Set(configData.delConfigs.map(i => i.path))
     }
   }
 };

--- a/src/main.ts
+++ b/src/main.ts
@@ -50,6 +50,9 @@ export default class FastSync extends Plugin {
   lastSyncMtime: Map<string, number> = new Map() // 最后同步的修改时间
   lastSyncPathDeleted: Set<string> = new Set() // 通过同步删除的路径
   lastSyncPathRenamed: Set<string> = new Set() // 通过同步重命名的路径
+  // 待确认的文件重命名队列，等待服务端 FileRenameAck 后再更新 hashManager
+  // Pending file rename queue, wait for server FileRenameAck before updating hashManager
+  pendingFileRenames: { oldPath: string; newPath: string; contentHash: string }[] = []
 
   syncTypeCompleteCount: number = 0 // 已完成同步的类型计数
   expectedSyncCount: number = 0 // 预期的同步类型计数

--- a/src/main.ts
+++ b/src/main.ts
@@ -53,6 +53,9 @@ export default class FastSync extends Plugin {
   // 待确认的文件重命名队列，等待服务端 FileRenameAck 后再更新 hashManager
   // Pending file rename queue, wait for server FileRenameAck before updating hashManager
   pendingFileRenames: { oldPath: string; newPath: string; contentHash: string }[] = []
+  // 待确认的文件上传 hash 映射，等待服务端 FileUploadAck 后再写入 hashManager
+  // Pending upload hash map, update hashManager only after server FileUploadAck
+  pendingUploadHashes: Map<string, string> = new Map()
 
   syncTypeCompleteCount: number = 0 // 已完成同步的类型计数
   expectedSyncCount: number = 0 // 预期的同步类型计数

--- a/src/main.ts
+++ b/src/main.ts
@@ -68,6 +68,12 @@ export default class FastSync extends Plugin {
   pendingDeleteFilePaths: Set<string> = new Set()
   pendingDeleteFolderPaths: Set<string> = new Set()
   pendingDeleteConfigPaths: Set<string> = new Set()
+  // 待服务端 NoteDeleteAck 确认的路径集合，Ack 到达后才从 hashManager 移除
+  // Paths pending NoteDeleteAck; remove from hashManager only after server confirms deletion
+  pendingNoteDeleteAcks: Set<string> = new Set()
+  // 待服务端 FileDeleteAck 确认的路径集合，Ack 到达后才从 hashManager 移除
+  // Paths pending FileDeleteAck; remove from hashManager only after server confirms deletion
+  pendingFileDeleteAcks: Set<string> = new Set()
 
   syncTypeCompleteCount: number = 0 // 已完成同步的类型计数
   expectedSyncCount: number = 0 // 预期的同步类型计数

--- a/src/main.ts
+++ b/src/main.ts
@@ -56,6 +56,18 @@ export default class FastSync extends Plugin {
   // 待确认的文件上传 hash 映射，等待服务端 FileUploadAck 后再写入 hashManager
   // Pending upload hash map, update hashManager only after server FileUploadAck
   pendingUploadHashes: Map<string, string> = new Map()
+  // 待确认的笔记上传 hash 映射，等待服务端 NoteModifyAck 后再写入 hashManager
+  // Pending note upload hash map, update hashManager only after server NoteModifyAck
+  pendingNoteModifies: Map<string, string> = new Map()
+  // 待确认的笔记重命名队列，等待服务端 NoteRenameAck 后再更新 hashManager（FIFO）
+  // Pending note rename FIFO queue, update hashManager only after server NoteRenameAck
+  pendingNoteRenames: { oldPath: string; newPath: string; contentHash: string }[] = []
+  // 待服务端确认删除的路径集合，SyncEnd 到达后再从 hashManager/snapshotManager 移除
+  // Pending delete path sets, remove from hashManager/snapshotManager only after SyncEnd arrives
+  pendingDeleteNotePaths: Set<string> = new Set()
+  pendingDeleteFilePaths: Set<string> = new Set()
+  pendingDeleteFolderPaths: Set<string> = new Set()
+  pendingDeleteConfigPaths: Set<string> = new Set()
 
   syncTypeCompleteCount: number = 0 // 已完成同步的类型计数
   expectedSyncCount: number = 0 // 预期的同步类型计数


### PR DESCRIPTION
## 概述

本 PR 修复了一类**同步状态分叉 Bug**——客户端在 WebSocket **on-send 回调**中更新 `hashManager`（客户端文件同步状态，持久化于 localStorage），而非在服务端确认后更新。同时修复了网络中断后重连时的文件重复和重传失败问题。

所有修复遵循同一原则：**推迟 hashManager 写入，直到服务端发送 ACK**。

---

## 背景

客户端维护一个 `hashManager` Map（`path → contentHash`），用于追踪哪些文件已同步到服务端。启动/重连时，`handleSync` 根据该 Map 计算三个集合：

- **needUpload** — 本地存在但不在 hashManager 中（或 hash 不匹配）
- **delNotes/delFiles** — 在 hashManager 中但本地不存在 → 应在服务端删除
- **needSyncMtime** — hash 一致但 mtime 不同

若 hashManager 在服务端处理消息**之前**就被更新（如在 on-send 回调中），TCP 连接中断会导致客户端 hash 状态与服务端产生分叉。操作被静默丢弃，永远不会重试。

---

## 改动说明

### 修复文件移动断连导致重复副本（`c1c5679`）

`fileRename` 此前在 on-send 回调中更新 hashManager（删除旧路径、设置新路径）。若在服务端收到消息前断连，旧路径从 hashManager 消失但仍在服务端，新路径进入 hashManager 但不在服务端 → 重连后旧路径不进入 `delFiles`，成为永久孤儿。

**修复方式**：将 on-send 回调替换为 FIFO 队列 `pendingFileRenames`。`receiveFileRenameAck`（新增）消费队列头部并应用 hashManager 更新。TCP 顺序保证 FIFO 匹配的正确性。

### 修复附件上传中断后不重传（`1b66e4b`）

`fileModify` 在 on-send 回调（FileUploadCheck）中将 hash 写入 hashManager。重连后，该文件显示"已同步"被跳过，即使服务端从未收到数据块。

**修复方式**：将 on-send hash 写入替换为 `pendingUploadHashes.set(path, contentHash)`。`receiveFileUploadAck`（已有 handler，增强版）将 hash 从 `pendingUploadHashes` 转移到 hashManager。增量过滤器跳过有活跃 pending 条目的文件（上传进行中），确保中断的上传在重连后重试。

### 修复笔记修改/重命名/删除 hash 更新时机（`b769bf1`）

三个操作的 hashManager 更新过早：

| 操作 | 旧行为 | 问题 |
|------|--------|------|
| NoteModify | on-send 回调 | 中断的修改被静默丢弃 |
| NoteRename | on-send 回调 | 断连 → 重复副本（新旧路径均成孤儿） |
| delNotes/delFiles（批量删除） | NoteSync 发送时立即执行 | 中断的批量删除 → 服务端保留已删文件 |

**修复方式**：
- **NoteModify**：`pendingNoteModifies` Map（`path → hash`）。`receiveNoteModifyAck` 提交到 hashManager。增量过滤器跳过有 pending 条目的路径（重连后重试）。
- **NoteRename**：`pendingNoteRenames` FIFO 队列。`receiveNoteRenameAck` 按顺序应用。
- **批量删除（delNotes / delFiles / delFolders / delConfigs）**：NoteSync/FileSync 发送时填充 `pendingDelete*` Set。对应的 `SyncEnd` handler 消费该 Set 并移除 hash。
- 除 `pendingNoteModifies`（按路径键控，跨重连存活）外，所有 pending set 在 `handleSync` 开始时清空。

### 修复 pendingNoteModifies 生命周期缺失的清理路径（`4acbe2a`）

主修复完成后，仍有四条服务端响应路径遗留了未被消费的 `pendingNoteModifies` 条目：

1. **`receiveNoteSyncModify`**（服务端推送其他设备的版本）：服务端内容覆盖本地 → 清除 pending，让增量过滤器在下次循环正确跳过该文件。
2. **`receiveNoteSyncDelete`**（服务端推送删除）：笔记在本地被删除 → 泄漏的 pending 条目，若路径被复用可能造成混乱。
3. **`receiveNoteSyncMtime`**（服务端确认 hash，仅 mtime 不同）：服务端已确认 hash 正确 → 将 pending hash 提交到 hashManager，而非让其泄漏。
4. **`receiveNoteUpload`**（服务端发送 NoteSyncNeedPush → 客户端重传）：将 on-send hash 写入替换为 `pendingNoteModifies.set()`，由 NoteModifyAck 驱动提交，中断的重传也能在重连后重试。

### 修复断连时 NoteDelete 和 FileDelete hash 移除问题（`f6f9230`）

`noteDelete` / `fileDelete` / `noteDeleteByPath` / `fileDeleteByPath` 在 on-send 回调中从 hashManager 移除 hash。若 TCP 在服务端收到消息前中断，hash 将永久消失。重连后，路径既不在 hashManager（hash 已删）也不在本地（文件已删）→ 不进入 `delNotes` → 服务端文件成为永久孤儿。

**修复方式**：引入 `pendingNoteDeleteAcks` 和 `pendingFileDeleteAcks` Set（与现有 `pendingNoteModifies` 对称）。hash 仅在收到 `NoteDeleteAck` / `FileDeleteAck`（服务端新增响应，见配套服务端 PR）后才被移除。重连时，`handleSync` 清空两个 Set，未确认的路径保留在 hashManager，自然流入 `delNotes`。

附加保护：
- `noteModify` / `fileModify`：当同路径被创建/上传时清除 pending delete 条目（新文件操作覆盖删除意图，防止晚到的 Ack 错误删除新 hash）。
- `receiveNoteSyncModify` / `receiveFileSyncUpdate`：对服务端推送到同路径的内容应用相同保护。

---

## 涉及文件

| 文件 | 改动内容 |
|------|---------|
| `src/main.ts` | 新增 `pendingUploadHashes`、`pendingNoteModifies`、`pendingNoteRenames`、`pendingFileRenames`、`pendingDelete*`、`pendingNoteDeleteAcks`、`pendingFileDeleteAcks` 状态字段 |
| `src/lib/note_operator.ts` | 重写修改/重命名/删除的 on-send 回调；新增 `receiveNoteModifyAck`、`receiveNoteRenameAck`、`receiveNoteDeleteAck`；在所有接收路径中补全生命周期清理 |
| `src/lib/file_operator.ts` | 附件侧对称改动；新增 `receiveFileRenameAck`、`receiveFileUploadAck`（增强版）、`receiveFileDeleteAck`；在 `receiveFileSyncUpdate` 中新增 `pendingFileDeleteAcks` 保护 |
| `src/lib/operator.ts` | 在 `receiveOperators` 中注册新 ACK handler；`handleSync` 开始时清空所有 pending set；在 NoteSync/FileSync 发送时绑定 `pendingDelete*` Set |
| `src/i18n/locales/*.ts`（5 个文件） | 为所有新 ACK action 类型添加 `ui.log.action.*` 文案条目 |

## 测试计划

- [ ] 正常修改/重命名/删除：确认 hash 仅在收到 ACK 后更新，而非发送时
- [ ] NoteModify 断连测试：停止服务端 → 编辑笔记 → 重启服务端 → 确认重连后笔记被重新上传
- [ ] NoteDelete 断连测试：停止服务端 → 删除笔记 → 重启服务端 → 确认重连后删除操作生效，服务端无孤儿
- [ ] 文件移动断连测试：移动附件 → 断连 → 重连 → 确认无重复副本
- [ ] 文件上传中断测试：开始上传大文件 → 中途断连 → 重连 → 确认重新上传完成
- [ ] 删除后立即创建同路径：删除笔记 → 立即创建同名笔记 → 确认 hash 无损坏