### PR TITLE
fix: 支持解析 JSON 格式的 configSyncOtherDirs (#134)

### DIFF
--- a/src/lib/helps.ts
+++ b/src/lib/helps.ts
@@ -250,9 +250,10 @@ export const configIsPathExcluded = function (relativePath: string, plugin: Fast
  */
 export const getConfigSyncCustomDirs = function (plugin: FastSync): string[] {
   const setting = plugin.settings.configSyncOtherDirs || ""
-  return setting
-    .split(/\r?\n/)
-    .map((p) => p.trim())
+  // 支持 JSON 格式（UI 保存格式）和旧版换行分隔格式
+  const rules = parseRules(setting)
+  return rules
+    .map((r) => r.pattern.trim().replace(/\/+$/, ""))  // 提取 pattern 并移除尾部斜杠
     .filter((p) => p !== "" && p.startsWith("."))
 }
 


### PR DESCRIPTION
## 问题描述

`setting.tsx` 以 JSON 数组格式保存 `configSyncOtherDirs`（如 `[{"pattern":".agents/"}]`），
但 `getConfigSyncCustomDirs()` 仍按换行分隔格式解析（`.split(/\\r?\\n/)`），导致：
- 解析结果始终为 `[]`
- 用户通过 UI 配置的自定义目录（如 `.agents`）永远不会被同步

## 根因分析

`parseRules()` 已支持 JSON 和换行两种格式（带缓存），但 `getConfigSyncCustomDirs()` 没有复用它，而是独立实现了解析逻辑。

## 修复方案

复用已有的 `parseRules()` 函数解析 `configSyncOtherDirs`，同时移除 pattern 尾部斜杠以保持与路径匹配的一致性。

Closes #134