### PR TITLE
fix(cloud-preview): use link path instead of getAvailablePathForAttachment

### DIFF
--- a/src/lib/file_cloud_preview.ts
+++ b/src/lib/file_cloud_preview.ts
@@ -552,7 +552,19 @@ export class FileCloudPreview {
     const { api, vault, apiToken, cloudPreviewEnabled, cloudPreviewTypeRestricted, cloudPreviewRemoteUrl } = this.plugin.settings;
     if (!cloudPreviewEnabled || !api || !apiToken) return null;
 
-    const vaultPath = await this.plugin.app.fileManager.getAvailablePathForAttachment(filePath, sourcePath);
+    // Use the link path as written in the markdown. processEmbed() has already
+    // verified that getFirstLinkpathDest(filePath, sourcePath) returns null
+    // (i.e. the file is not present locally — typically because
+    // cloudPreviewAutoDeleteLocal removed it after upload), so the only
+    // authoritative location of the file is the path the user wrote in the
+    // link. getAvailablePathForAttachment() must NOT be used here: it returns
+    // the *destination path for a NEW attachment* based on the user's
+    // attachment-folder configuration, not the actual storage path of an
+    // existing file. For embeds like ![[attachment/yuque/X.mp3]] it would
+    // typically discard the directory and return just "X.mp3" (or worse,
+    // produce a path under the note's folder), causing the resulting cloud
+    // URL to 404 on the server.
+    const vaultPath = filePath;
     const ext = this.getFileExtension(vaultPath);
     if (!ext) return null;
 


### PR DESCRIPTION
## Problem

`FileCloudPreview.getCloudUrl()` derives the cloud URL's `path=` query
parameter from `app.fileManager.getAvailablePathForAttachment(filePath, sourcePath)`.

That Obsidian API returns the *destination path for a NEW attachment* based
on the user's attachment-folder configuration — it is not the storage path
of an existing file. When `cloudPreviewAutoDeleteLocal` is on, the local
file is removed after upload, and on subsequent renders `processEmbed`
calls `getCloudUrl` to build a preview URL. The wrong path is then sent to
the server.

### Reproduction

1. Set `cloudPreviewEnabled: true` and `cloudPreviewAutoDeleteLocal: true`.
2. In a note (e.g. `notes/folder/sub/note.md`), embed an attachment with a
   vault-relative path: `![[attachment/yuque/X.mp3]]`.
3. Upload completes, local file at `attachment/yuque/X.mp3` is auto-deleted.
4. Re-open the note. The cloud preview fails:
   - The request URL contains `path=X.mp3` (directory discarded), or
     `path=notes/folder/sub/X.mp3` (resolved against note's folder),
     depending on the `attachmentFolderPath` setting.
   - The server returns 404 because the file is actually stored at
     `attachment/yuque/X.mp3`.

This affects all media types (audio/video/image/PDF) once the local copy
is removed.

## Fix

`processEmbed()` already calls `getFirstLinkpathDest(filePath, sourcePath)`
and bails early if the file resolves locally. So by the time `getCloudUrl`
is reached, the file is *known* not to be present in the vault index, and
the only authoritative location is the path the user wrote in the link.
Use `filePath` directly.

```diff
- const vaultPath = await this.plugin.app.fileManager.getAvailablePathForAttachment(filePath, sourcePath);
+ const vaultPath = filePath;
```

`sourcePath` is now unused inside `getCloudUrl` but kept in the signature
for API stability.

## Verification

Tested against a deployed `fast-note-sync-service` on Synology DSM (v2.12.9).
Before fix: `GET /api/file?path=X.mp3` → 404. After fix:
`GET /api/file?path=attachment/yuque/X.mp3` → 200 with correct
`Content-Type: audio/mp4` and Range support; the embedded `<audio>` element
plays end-to-end.

## Notes

- Bug reproduces on every recent build (verified with v1.22.10, v1.22.13,
  v1.24.6 from the community plugin marketplace).
- No behavior change for the local-file path: `processEmbed` short-circuits
  before `getCloudUrl` for files that exist locally.
- No new dependencies; no test framework appears in the repo, so no tests
  added.