### PR TITLE
fix: probeApiRedirect 应尊重 networkLibrary 设置，修复 iOS 连接失败 (#142)

### DIFF
--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -58,27 +58,44 @@ export class HttpApiService {
         const base = urlToProbe.replace(/\/+$/, "");
         const probeUrl = addRandomParam(base + "/api/health");
 
+        const networkLibrary = this.plugin.settings.networkLibrary;
+        const headers: Record<string, string> = {
+            "x-client": "ObsidianPlugin",
+            "x-client-name": encodeURIComponent(this.plugin.getClientName()),
+            "x-client-version": this.plugin.manifest.version || ""
+        };
+
         try {
-            // 默认优先用 fetch 探测以获取 301/302 后的最终路径
-            const res = await fetch(probeUrl, {
-                method: 'GET',
-                redirect: 'follow',
-                headers: {
-                    "x-client": "ObsidianPlugin",
-                    "x-client-name": encodeURIComponent(this.plugin.getClientName()),
-                    "x-client-version": this.plugin.manifest.version || ""
+            if (networkLibrary === 'requestUrl') {
+                // 使用 Obsidian requestUrl 探测（不受 iOS WKWebView CORS 限制）
+                const response = await requestUrl({
+                    url: probeUrl,
+                    method: 'GET',
+                    headers: headers,
+                    throw: false
+                });
+                // requestUrl 自动跟随重定向，response.headers 可能包含重定向信息
+                // 但最重要的是确认服务端可达且健康
+                this.plugin.updateRuntimeApi(base);
+                return response.status >= 200 && response.status < 400;
+            } else {
+                // 使用原生 fetch 探测以获取 301/302 后的最终路径
+                const res = await fetch(probeUrl, {
+                    method: 'GET',
+                    redirect: 'follow',
+                    headers: headers
+                });
+                if (res.url) {
+                    const healthIndex = res.url.indexOf("/api/health");
+                    if (healthIndex !== -1) {
+                        const newBase = res.url.substring(0, healthIndex).replace(/\/+$/, "");
+                        this.plugin.updateRuntimeApi(newBase);
+                    } else {
+                        this.plugin.updateRuntimeApi(base);
+                    }
                 }
-            });
-            if (res.url) {
-                const healthIndex = res.url.indexOf("/api/health");
-                if (healthIndex !== -1) {
-                    const newBase = res.url.substring(0, healthIndex).replace(/\/+$/, "");
-                    this.plugin.updateRuntimeApi(newBase);
-                } else {
-                    this.plugin.updateRuntimeApi(base);
-                }
+                return res.ok;
             }
-            return res.ok;
         } catch (e) {
             // 即使失败，也确保 runApi 有值（回退到探测的 base）
             this.plugin.updateRuntimeApi(base);


### PR DESCRIPTION
## 问题描述

**Issue:** #142 — iOS 更新 1.25.0-alpha 后无法连接服务器，回退到 1.24.6-alpha 恢复正常。

## 根因分析

v1.25.0 在 WebSocket 连接前新增了 `/api/health` 健康检查作为**阻塞门控**：

```typescript
// websocket.ts - register() 改为 async
public async register() {
    // ...
    const isHealthy = await this.plugin.api.probeApiRedirect(this.plugin.runApi);
    if (!isHealthy) {
        // 永远不连接 WebSocket
        this.checkReConnect();
        return;
    }
    // 只有健康检查通过才连接 WS
}
```

但 `probeApiRedirect()` 方法**始终使用原生 `fetch` API**，忽略了用户的 `networkLibrary` 设置：

```typescript
// api.ts - 修改前（v1.25.0）
async probeApiRedirect() {
    // 始终使用 fetch —— 不受 CORS 豁免
    const res = await fetch(probeUrl, { ... });
}
```

而其他所有 API 调用（`request()` 方法）会根据 `settings.networkLibrary` 选择 `requestUrl`（Obsidian 内置，不受 CORS 限制）或 `fetch`：

```typescript
// api.ts - request() 方法
const networkLibrary = this.plugin.settings.networkLibrary;
if (networkLibrary === requestUrl) {
    const response = await requestUrl({ ... });
} else {
    const res = await fetch(url, fetchOptions);
}
```

在 iOS 的 WKWebView 中，原生 `fetch` 可能因 CORS 或 App Transport Security (ATS) 限制而失败。当用户使用 `requestUrl` 作为网络库时，**其他 API 调用正常但健康检查失败**，导致 WebSocket 永远不连接。

## 修复方案

让 `probeApiRedirect` 尊重 `settings.networkLibrary` 设置，使用与 `request()` 相同的网络请求方式：

- **`requestUrl` 模式**：使用 Obsidian 的 `requestUrl`（不受 iOS CORS 限制）
- **`fetch` 模式**：保持原有 `fetch` 行为（桌面端正常）

## 修改范围

仅修改 `src/lib/api.ts` 的 `probeApiRedirect` 方法，约 35 行新增 / 18 行删除。

## 测试建议

1. **iOS**：安装此修复版本，确认 WebSocket 能正常连接
2. **桌面端**：分别测试 `requestUrl` 和 `fetch` 两种网络库设置
3. **重定向场景**：确认 301/302 跳转场景仍正常工作