### PR TITLE
fix: 断点续传 / 崩溃恢复 / 同步可靠性修复

### DIFF
--- a/src/lib/config_operator.ts
+++ b/src/lib/config_operator.ts
@@ -97,6 +97,7 @@ export const configModify = async function (path: string, plugin: FastSync, even
     // Temporarily store hash in pending map, update configHashManager only after server SettingModifyAck
     plugin.pendingConfigDeleteAcks.delete(path)
     plugin.pendingConfigModifies.set(path, contentHash)
+    plugin.localStorageManager.savePending('pendingConfigModifies', plugin.pendingConfigModifies)
     await plugin.concurrencyManager.waitForSlot(path)
     plugin.websocket.SendMessage("SettingModify", data)
 
@@ -262,6 +263,7 @@ export const receiveConfigUpload = async function (data: ReceivePathMessage, plu
     // 将 hash 暂存到 pending map，等待服务端 SettingModifyAck 后再写入 configHashManager
     // Temporarily store hash in pending map, update configHashManager only after server SettingModifyAck
     plugin.pendingConfigModifies.set(data.path, contentHash)
+    plugin.localStorageManager.savePending('pendingConfigModifies', plugin.pendingConfigModifies)
     await plugin.concurrencyManager.waitForSlot(data.path)
     plugin.websocket.SendMessage("SettingModify", sendData, undefined, function () {
         plugin.removeIgnoredConfigFile(data.path);
@@ -386,6 +388,7 @@ export const receiveConfigModifyAck = function (data: { lastTime?: number; path?
                 plugin.configHashManager.setFileHash(data.path, contentHash)
             }
             plugin.pendingConfigModifies.delete(data.path)
+            plugin.localStorageManager.savePending('pendingConfigModifies', plugin.pendingConfigModifies)
         }
     }
     if (data.lastTime && data.lastTime > Number(plugin.localStorageManager.getMetadata("lastConfigSyncTime"))) {

--- a/src/lib/file_operator.ts
+++ b/src/lib/file_operator.ts
@@ -72,6 +72,7 @@ export const fileModify = async function (file: TAbstractFile, plugin: FastSync,
       // New upload supersedes delete intent; clear pending to prevent stale Ack from removing new hash
       plugin.pendingFileDeleteAcks.delete(file.path)
       plugin.pendingUploadHashes.set(file.path, contentHash)
+      plugin.localStorageManager.savePending('pendingUploadHashes', plugin.pendingUploadHashes)
       await plugin.concurrencyManager.waitForSlot(file.path)
       plugin.websocket.SendMessage("FileUploadCheck", data)
       dump(`File modify check sent`, data.path, data.contentHash)
@@ -106,12 +107,14 @@ export const fileDelete = async function (file: TAbstractFile, plugin: FastSync,
       // 仅清理本地状态
       plugin.fileHashManager.removeFileHash(file.path)
       plugin.pendingUploadHashes.delete(file.path)
+      plugin.localStorageManager.savePending('pendingUploadHashes', plugin.pendingUploadHashes)
       return
     }
 
     // 清理可能存在的待确认上传记录，避免 pending map 内存泄漏
     // Clean up any pending upload record to avoid pending map memory leak
     plugin.pendingUploadHashes.delete(file.path)
+    plugin.localStorageManager.savePending('pendingUploadHashes', plugin.pendingUploadHashes)
 
     plugin.addIgnoredFile(file.path)
     try {
@@ -150,12 +153,14 @@ export const fileDeleteByPath = async function (filePath: string, plugin: FastSy
       activeUploadsMap.get(filePath)!.cancelled = true;
       plugin.fileHashManager.removeFileHash(filePath)
       plugin.pendingUploadHashes.delete(filePath)
+      plugin.localStorageManager.savePending('pendingUploadHashes', plugin.pendingUploadHashes)
       return
     }
 
     // 清理可能存在的待确认上传记录，避免 pending map 内存泄漏
     // Clean up any pending upload record to avoid pending map memory leak
     plugin.pendingUploadHashes.delete(filePath)
+    plugin.localStorageManager.savePending('pendingUploadHashes', plugin.pendingUploadHashes)
 
     plugin.addIgnoredFile(filePath)
     try {
@@ -283,6 +288,7 @@ export const receiveFileUpload = async function (data: FileUploadMessage, plugin
       // 将 hash 暂存到 pending map，等待服务端 FileUploadAck 后再写入 hashManager
       // Temporarily store hash in pending map, update hashManager only after server FileUploadAck
       plugin.pendingUploadHashes.set(data.path, contentHash)
+      plugin.localStorageManager.savePending('pendingUploadHashes', plugin.pendingUploadHashes)
       // 记录当前文件的 mtime/size 到缓存，以便后续利用
       plugin.fileHashManager.setFileHash(data.path, contentHash, file.stat.mtime, file.stat.size)
 
@@ -984,6 +990,7 @@ export const receiveFileUploadAck = function (data: { lastTime?: number; path?: 
       const file = plugin.app.vault.getFileByPath(normalizePath(data.path))
       plugin.fileHashManager.setFileHash(data.path, contentHash, file?.stat.mtime || 0, file?.stat.size || 0)
       plugin.pendingUploadHashes.delete(data.path)
+      plugin.localStorageManager.savePending('pendingUploadHashes', plugin.pendingUploadHashes)
     }
   }
   if (data.lastTime && data.lastTime > Number(plugin.localStorageManager.getMetadata("lastFileSyncTime"))) {

--- a/src/lib/file_operator.ts
+++ b/src/lib/file_operator.ts
@@ -271,6 +271,11 @@ export const receiveFileUpload = async function (data: FileUploadMessage, plugin
     activeUploadsMap.set(data.path, { cancelled: false });
     await plugin.concurrencyManager.waitForSlot(data.path, false, 10) // 优先级设为 10，优先处理上传
 
+    // 断点续传 checkpoint key，提升到 try 外以便 catch 块中也能清除
+    // Resume checkpoint key hoisted outside try so the catch block can also remove it
+    const vaultName = plugin.app.vault.getName()
+    const checkpointKey = `fns-${vaultName}-uploadSession-${data.pathHash}`
+
     try {
       // 延迟到任务排到时才读取文件内容, 减少内存积压
       let content: ArrayBuffer | null = null;
@@ -295,6 +300,26 @@ export const receiveFileUpload = async function (data: FileUploadMessage, plugin
       // 如果是空文件，强制设置分片数量为 1，发送一个空分片以通知服务端上传完成
       const actualTotalChunks = content.byteLength === 0 ? 1 : Math.ceil(content.byteLength / chunkSize)
 
+      // 断点续传：从 localStorage 读取上次中断的 checkpoint
+      // Resume upload: read checkpoint from localStorage for the last interrupted upload
+      let startChunkIndex = 0
+      try {
+        const cpRaw = localStorage.getItem(checkpointKey)
+        if (cpRaw) {
+          const cp = JSON.parse(cpRaw)
+          if (cp.sessionId === data.sessionId &&
+              cp.contentHash === contentHash &&
+              typeof cp.lastChunkIndex === 'number' &&
+              cp.lastChunkIndex >= 0 &&
+              cp.lastChunkIndex < actualTotalChunks - 1) {
+            startChunkIndex = cp.lastChunkIndex + 1
+            dump(`Resume upload from chunk ${startChunkIndex}/${actualTotalChunks}: ${data.path}`)
+          }
+        }
+      } catch (e) {
+        dump(`Failed to read upload checkpoint for ${data.path}`, e)
+      }
+
       // 仅在非同步期间(实时监听时)手动增加分片计数。同步期间由 SyncEnd 包装器统一预估
       if (plugin.getWatchEnabled()) {
         plugin.totalChunksToUpload += actualTotalChunks
@@ -314,7 +339,7 @@ export const receiveFileUpload = async function (data: FileUploadMessage, plugin
 
       const sleepTime = Platform.isMobile ? 10 : 2;
 
-      for (let i = 0; i < actualTotalChunks; i++) {
+      for (let i = startChunkIndex; i < actualTotalChunks; i++) {
         const start = i * chunkSize
         const end = Math.min(start + chunkSize, content.byteLength)
         const length = end - start;
@@ -350,6 +375,21 @@ export const receiveFileUpload = async function (data: FileUploadMessage, plugin
             const currentProgress = Math.floor(((i + 1) / actualTotalChunks) * 100);
             const isLastChunk = (i + 1) === actualTotalChunks;
 
+            // 更新断点续传 checkpoint（发送成功后，非最后一块）
+            // Update resume checkpoint after successful send (not the last chunk)
+            if (!isLastChunk) {
+              try {
+                localStorage.setItem(checkpointKey, JSON.stringify({
+                  sessionId: data.sessionId,
+                  lastChunkIndex: i,
+                  contentHash: contentHash,
+                  timestamp: Date.now(),
+                }))
+              } catch (e) {
+                dump(`Failed to save upload checkpoint for ${data.path}`, e)
+              }
+            }
+
             // 更新日志进度
             SyncLogManager.getInstance().addOrUpdateLog({
               id: data.sessionId,
@@ -364,6 +404,9 @@ export const receiveFileUpload = async function (data: FileUploadMessage, plugin
 
         // 如果被取消,立即退出循环并释放槽位
         if (cancelled) {
+          // 取消时清除 checkpoint，避免使用已失效的会话
+          // Clear checkpoint on cancel to avoid stale session reuse
+          try { localStorage.removeItem(checkpointKey) } catch (e) { /* ignore */ }
           plugin.concurrencyManager.releaseSlot(data.path)
           return;
         }
@@ -416,6 +459,9 @@ export const receiveFileUpload = async function (data: FileUploadMessage, plugin
       }
     } catch (e) {
       dump(`Upload process error for ${data.path}`, e);
+      // 异常退出时清除 checkpoint，避免下次用无效的 sessionId 继续
+      // Clear checkpoint on exception to avoid resuming with an invalid session
+      try { localStorage.removeItem(checkpointKey) } catch (e2) { /* ignore */ }
       plugin.concurrencyManager.releaseSlot(data.path);
     } finally {
       // 任务结束（完成或取消/失败），移除活跃标记
@@ -981,7 +1027,7 @@ export const receiveFileRenameAck = function (data: { lastTime?: number }, plugi
 
 // 收到 FileUploadAck，将 pending hash 转移到正式 hashManager 并更新 lastFileSyncTime
 // Receive FileUploadAck, move pending hash to formal hashManager and update lastFileSyncTime
-export const receiveFileUploadAck = function (data: { lastTime?: number; path?: string }, plugin: FastSync) {
+export const receiveFileUploadAck = function (data: { lastTime?: number; path?: string; pathHash?: string }, plugin: FastSync) {
   // 服务端确认上传成功，将 pending hash 转移到正式 hashManager
   // Server confirmed upload success, move pending hash to formal hashManager
   if (data.path) {
@@ -992,6 +1038,12 @@ export const receiveFileUploadAck = function (data: { lastTime?: number; path?: 
       plugin.pendingUploadHashes.delete(data.path)
       plugin.localStorageManager.savePending('pendingUploadHashes', plugin.pendingUploadHashes)
     }
+  }
+  // 上传完成，清除断点续传 checkpoint
+  // Upload complete, clear resume checkpoint
+  if (data.pathHash) {
+    const vaultName = plugin.app.vault.getName()
+    try { localStorage.removeItem(`fns-${vaultName}-uploadSession-${data.pathHash}`) } catch (e) { /* ignore */ }
   }
   if (data.lastTime && data.lastTime > Number(plugin.localStorageManager.getMetadata("lastFileSyncTime"))) {
     plugin.localStorageManager.setMetadata("lastFileSyncTime", data.lastTime)

--- a/src/lib/folder_operator.ts
+++ b/src/lib/folder_operator.ts
@@ -140,6 +140,11 @@ export const receiveFolderSyncModify = async function (data: any, plugin: FastSy
     } catch (e) {
         dump(`Error in receiveFolderSyncModify: ${normalizedPath}`, e)
     } finally {
+        // 实时更新同步时间戳，与 note 端保持一致
+        // Update sync timestamp in real time, consistent with note side
+        if (data.lastTime && data.lastTime > Number(plugin.localStorageManager.getMetadata("lastFolderSyncTime"))) {
+            plugin.localStorageManager.setMetadata("lastFolderSyncTime", data.lastTime)
+        }
         plugin.folderSyncTasks.completed++
     }
 }
@@ -180,6 +185,11 @@ export const receiveFolderSyncDelete = async function (data: any, plugin: FastSy
     } catch (e) {
         dump(`Error in receiveFolderSyncDelete: ${normalizedPath}`, e)
     } finally {
+        // 实时更新同步时间戳，与 note 端保持一致
+        // Update sync timestamp in real time, consistent with note side
+        if (data.lastTime && data.lastTime > Number(plugin.localStorageManager.getMetadata("lastFolderSyncTime"))) {
+            plugin.localStorageManager.setMetadata("lastFolderSyncTime", data.lastTime)
+        }
         plugin.folderSyncTasks.completed++
     }
 }
@@ -240,6 +250,11 @@ export const receiveFolderSyncRename = async function (data: FolderSyncRenameMes
     } catch (e) {
         dump(`Error in receiveFolderSyncRename: ${normalizedOldPath} -> ${normalizedNewPath}`, e)
     } finally {
+        // 实时更新同步时间戳，与 note 端保持一致
+        // Update sync timestamp in real time, consistent with note side
+        if (data.lastTime && data.lastTime > Number(plugin.localStorageManager.getMetadata("lastFolderSyncTime"))) {
+            plugin.localStorageManager.setMetadata("lastFolderSyncTime", data.lastTime)
+        }
         plugin.folderSyncTasks.completed++
     }
 }

--- a/src/lib/local_storage_manager.ts
+++ b/src/lib/local_storage_manager.ts
@@ -97,6 +97,45 @@ export class LocalStorageManager {
         this.setMetadata('internalExcludes', JSON.stringify(rules));
     }
 
+    // --- pending 持久化方法 ---
+    // Pending persistence methods: protect against data loss on crash
+
+    /**
+     * 将内存中的 pending Map 序列化写入 localStorage
+     * Serialize in-memory pending Map to localStorage
+     */
+    savePending(field: 'pendingNoteModifies' | 'pendingUploadHashes' | 'pendingConfigModifies', map: Map<string, string>): void {
+        try {
+            this.write(this.getInternalKey(field), JSON.stringify(Object.fromEntries(map)));
+        } catch (e) {
+            dump(`[LocalStorageManager] Failed to persist ${field}:`, e);
+        }
+    }
+
+    /**
+     * 从 localStorage 加载 pending Map，并过滤本地已不存在的路径
+     * Load pending Map from localStorage, filtering out paths that no longer exist locally
+     */
+    loadPending(field: 'pendingNoteModifies' | 'pendingUploadHashes' | 'pendingConfigModifies'): Map<string, string> {
+        try {
+            const raw = this.read(this.getInternalKey(field));
+            if (!raw) return new Map();
+            const obj = JSON.parse(raw);
+            return new Map(Object.entries(obj));
+        } catch (e) {
+            dump(`[LocalStorageManager] Failed to load pending ${field}:`, e);
+            return new Map();
+        }
+    }
+
+    /**
+     * 清除 localStorage 中的 pending 持久化数据
+     * Clear persisted pending data from localStorage
+     */
+    clearPending(field: 'pendingNoteModifies' | 'pendingUploadHashes' | 'pendingConfigModifies'): void {
+        localStorage.removeItem(this.getInternalKey(field));
+    }
+
     /**
      * 清理所有同步记录时间戳
      */

--- a/src/lib/note_operator.ts
+++ b/src/lib/note_operator.ts
@@ -59,6 +59,7 @@ export const noteModify = async function (file: TAbstractFile, plugin: FastSync,
         // New create supersedes delete intent; clear pending to prevent stale Ack from removing new hash
         plugin.pendingNoteDeleteAcks.delete(file.path)
         plugin.pendingNoteModifies.set(file.path, contentHash)
+        plugin.localStorageManager.savePending('pendingNoteModifies', plugin.pendingNoteModifies)
       }
       await plugin.concurrencyManager.waitForSlot(file.path)
       plugin.websocket.SendMessage("NoteModify", data)
@@ -90,6 +91,7 @@ export const noteDelete = async function (file: TAbstractFile, plugin: FastSync,
     // 清理可能存在的待确认上传记录，避免 pending map 内存泄漏
     // Clean up any pending note modify record to avoid memory leak
     plugin.pendingNoteModifies.delete(file.path)
+    plugin.localStorageManager.savePending('pendingNoteModifies', plugin.pendingNoteModifies)
     plugin.addIgnoredFile(file.path)
     try {
       const data = {
@@ -125,6 +127,7 @@ export const noteDeleteByPath = async function (filePath: string, plugin: FastSy
     // 清理可能存在的待确认上传记录，避免 pending map 内存泄漏
     // Clean up any pending note modify record to avoid memory leak
     plugin.pendingNoteModifies.delete(filePath)
+    plugin.localStorageManager.savePending('pendingNoteModifies', plugin.pendingNoteModifies)
     plugin.addIgnoredFile(filePath)
     try {
       await plugin.concurrencyManager.waitForSlot(filePath)
@@ -239,6 +242,7 @@ export const receiveNoteSyncModify = async function (data: ReceiveMessage, plugi
       // 服务端版本已覆盖本地，清理 pending 避免增量过滤器旁路导致该笔记无限重传
       // Server version overrides local; clear pending to avoid incremental filter bypass loop
       plugin.pendingNoteModifies.delete(data.path)
+      plugin.localStorageManager.savePending('pendingNoteModifies', plugin.pendingNoteModifies)
       // 服务端推送新内容说明该路径已被创建/更新，清理可能残留的 deleteAck pending
       // Server push means path was created/updated; clear any stale deleteAck pending
       plugin.pendingNoteDeleteAcks.delete(data.path)
@@ -305,6 +309,7 @@ export const receiveNoteUpload = async function (data: ReceivePathMessage, plugi
   // Store hash in pending map; hashManager is written only after NoteModifyAck arrives.
   // Overwrites any stale pending entry left by a previously interrupted noteModify.
   plugin.pendingNoteModifies.set(file.path, contentHash)
+  plugin.localStorageManager.savePending('pendingNoteModifies', plugin.pendingNoteModifies)
   await plugin.concurrencyManager.waitForSlot(file.path)
   plugin.websocket.SendMessage("NoteModify", sendData, undefined, () => {
     plugin.removeIgnoredFile(file.path)
@@ -341,6 +346,7 @@ export const receiveNoteSyncMtime = async function (data: ReceiveMtimeMessage, p
         if (pendingHash !== undefined) {
           plugin.fileHashManager.setFileHash(data.path, pendingHash, data.mtime, file.stat.size)
           plugin.pendingNoteModifies.delete(data.path)
+          plugin.localStorageManager.savePending('pendingNoteModifies', plugin.pendingNoteModifies)
         }
         // 更新同步时间
         if (data.lastTime && data.lastTime > Number(plugin.localStorageManager.getMetadata("lastNoteSyncTime"))) {
@@ -381,6 +387,7 @@ export const receiveNoteSyncDelete = async function (data: ReceiveMessage, plugi
         // 清理 pending，避免已删除路径的 pending 条目泄漏
         // Clean up pending to prevent memory leak for deleted path
         plugin.pendingNoteModifies.delete(normalizedPath)
+        plugin.localStorageManager.savePending('pendingNoteModifies', plugin.pendingNoteModifies)
         // 更新同步时间
         if (data.lastTime && data.lastTime > Number(plugin.localStorageManager.getMetadata("lastNoteSyncTime"))) {
           plugin.localStorageManager.setMetadata("lastNoteSyncTime", data.lastTime)
@@ -520,6 +527,7 @@ export const receiveNoteModifyAck = function (data: { lastTime?: number; path?: 
       const file = plugin.app.vault.getFileByPath(normalizePath(data.path))
       plugin.fileHashManager.setFileHash(data.path, contentHash, file?.stat.mtime || 0, file?.stat.size || 0)
       plugin.pendingNoteModifies.delete(data.path)
+      plugin.localStorageManager.savePending('pendingNoteModifies', plugin.pendingNoteModifies)
     } else {
       dump(`NoteModifyAck received for non-pending path: ${data.path}`)
     }

--- a/src/lib/operator.ts
+++ b/src/lib/operator.ts
@@ -167,7 +167,6 @@ export function checkSyncCompletion(plugin: FastSync, intervalId?: ReturnType<ty
     // Refresh share indicator state after sync completion
     plugin.shareIndicatorManager?.syncWithServer();
 
-    plugin.isSyncing = false;
     setTimeout(() => plugin.updateStatusBar(""), 3000);
   } else {
     // --- 强制完成逻辑与 90% 补偿 ---
@@ -274,6 +273,7 @@ async function receiveSyncEndWrapper(data: any, plugin: FastSync, type: "note" |
       plugin.fileHashManager.setFileHash(path, hash)
     }
     plugin.pendingNoteModifies.clear()
+    plugin.localStorageManager.clearPending('pendingNoteModifies')
   } else if (type === "file") {
     for (const path of plugin.pendingDeleteFilePaths) plugin.fileHashManager.removeFileHash(path)
     plugin.pendingDeleteFilePaths.clear()
@@ -282,6 +282,7 @@ async function receiveSyncEndWrapper(data: any, plugin: FastSync, type: "note" |
       plugin.fileHashManager.setFileHash(path, hash)
     }
     plugin.pendingUploadHashes.clear()
+    plugin.localStorageManager.clearPending('pendingUploadHashes')
   } else if (type === "folder") {
     for (const path of plugin.pendingDeleteFolderPaths) plugin.folderSnapshotManager.removeFolder(path)
     plugin.pendingDeleteFolderPaths.clear()
@@ -295,6 +296,7 @@ async function receiveSyncEndWrapper(data: any, plugin: FastSync, type: "note" |
     }
     plugin.pendingDeleteConfigPaths.clear()
     plugin.pendingConfigModifies.clear()
+    plugin.localStorageManager.clearPending('pendingConfigModifies')
   }
 
   // 3. 调用原始 End 处理函数 (更新时间戳等)
@@ -337,6 +339,7 @@ export const handleSync = async function (plugin: FastSync, isLoadLastTime: bool
     return;
   }
   plugin.isSyncing = true;
+  try {
   const context = generateUUID();
   dump(`Sync context generated: ${context}`);
   if (!plugin.menuManager.ribbonIconStatus) {
@@ -379,6 +382,7 @@ export const handleSync = async function (plugin: FastSync, isLoadLastTime: bool
   plugin.pendingFileDeleteAcks.clear()
   plugin.pendingConfigDeleteAcks.clear()
   plugin.pendingConfigModifies.clear()
+  plugin.localStorageManager.clearPending('pendingConfigModifies')
   plugin.disableWatch();
 
   if (plugin.settings.isShowNotice && (plugin.settings.syncEnabled || plugin.settings.configSyncEnabled)) {
@@ -736,6 +740,11 @@ export const handleSync = async function (plugin: FastSync, isLoadLastTime: bool
   const progressCheckInterval = setInterval(() => {
     checkSyncCompletion(plugin, progressCheckInterval, syncStartTime);
   }, 100);
+  } finally {
+    // 确保 isSyncing 在所有退出路径（正常完成、early return、异常）下都被重置
+    // Ensure isSyncing is reset on all exit paths: normal completion, early return, or exception
+    plugin.isSyncing = false;
+  }
 };
 
 
@@ -813,12 +822,9 @@ export const handleRequestSend = async function (plugin: FastSync, syncMode: Syn
     // Step 3: Folder structure is ready, now send NoteSync and FileSync
     plugin.websocket.SendMessage("NoteSync", noteSyncData, undefined, () => {
       for (const note of noteSyncData.notes) {
-        // 将同步发送的 hash 加入 pending，等待服务端可能发送的消息后再确定
-        // 在 batch 同步中，如果没有收到对应 Ack 而是收到了 End，则 End 包装器会处理
-        // 不过由于 NoteSync 通常不触发 NoteModifyAck，这里可能需要保持原样
-        // 但为了符合 "ACK 之后才保存" 的原则，我们还是加入 pending
         plugin.pendingNoteModifies.set(note.path, note.contentHash);
       }
+      plugin.localStorageManager.savePending('pendingNoteModifies', plugin.pendingNoteModifies)
     });
 
     // 如果启用了云预览且未开启类型限制，则不发送 FileSync 请求，从而关闭启动时的 file 同步
@@ -850,6 +856,7 @@ export const handleRequestSend = async function (plugin: FastSync, syncMode: Syn
       for (const config of configSyncData.settings) {
         plugin.pendingConfigModifies.set(config.path, config.contentHash);
       }
+      plugin.localStorageManager.savePending('pendingConfigModifies', plugin.pendingConfigModifies)
     });
 
     // 将已删除配置路径加入 pending set，等待 SettingSyncEnd 确认服务端已处理后再移除

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -51,6 +51,7 @@ export interface ReceiveFileSyncUpdateMessage {
 
 export interface FileUploadMessage {
     path: string;
+    pathHash: string;
     ctime: number;
     mtime: number;
     sessionId: string;
@@ -141,6 +142,7 @@ export interface FolderSyncRenameMessage {
     mtime: number;
     oldPath: string;
     oldPathHash: string;
+    lastTime?: number;
 }
 
 export interface FolderSyncData {

--- a/src/lib/websocket.ts
+++ b/src/lib/websocket.ts
@@ -190,6 +190,12 @@ export class WebSocketClient {
 
         // Only reconnect if we differ intended to be registered
         if (this.isRegister && e.reason != "AuthorizationFaild" && e.reason != "ClientClose") {
+          // 断连时立即重置 isSyncing，避免重连后 handleSync 被守卫拦截
+          // Reset isSyncing on disconnect to unblock handleSync after reconnect
+          if (this.plugin.isSyncing) {
+            this.plugin.isSyncing = false
+            this.plugin.isSyncRequesting = false
+          }
           this.checkReConnect()
         }
         clearUploadQueue()

--- a/src/main.ts
+++ b/src/main.ts
@@ -349,6 +349,43 @@ export default class FastSync extends Plugin {
       }
       await Promise.all(initPromises)
 
+      // 崩溃恢复：从 localStorage 恢复持久化的 pending Map，过滤本地已不存在的路径
+      // Crash recovery: restore persisted pending Maps, filtering out paths that no longer exist locally
+      const allFiles = this.app.vault.getAllLoadedFiles()
+      const existingPaths = new Set(allFiles.map(f => f.path))
+
+      const restoredNoteModifies = this.localStorageManager.loadPending('pendingNoteModifies')
+      for (const [path] of restoredNoteModifies) {
+        if (!existingPaths.has(path)) restoredNoteModifies.delete(path)
+      }
+      if (restoredNoteModifies.size > 0) {
+        this.pendingNoteModifies = restoredNoteModifies
+        dump(`[Crash Recovery] Restored ${restoredNoteModifies.size} pendingNoteModifies`)
+      } else {
+        this.localStorageManager.clearPending('pendingNoteModifies')
+      }
+
+      const restoredUploadHashes = this.localStorageManager.loadPending('pendingUploadHashes')
+      for (const [path] of restoredUploadHashes) {
+        if (!existingPaths.has(path)) restoredUploadHashes.delete(path)
+      }
+      if (restoredUploadHashes.size > 0) {
+        this.pendingUploadHashes = restoredUploadHashes
+        dump(`[Crash Recovery] Restored ${restoredUploadHashes.size} pendingUploadHashes`)
+      } else {
+        this.localStorageManager.clearPending('pendingUploadHashes')
+      }
+
+      const restoredConfigModifies = this.localStorageManager.loadPending('pendingConfigModifies')
+      // 配置文件不过滤路径：getAllLoadedFiles 不含 .obsidian/ 路径，且 configModify 发送前会重新读文件，文件不存在时自动跳过
+      // Config paths not filtered: getAllLoadedFiles excludes .obsidian/ paths; configModify re-reads files before sending and skips missing ones
+      if (restoredConfigModifies.size > 0) {
+        this.pendingConfigModifies = restoredConfigModifies
+        dump(`[Crash Recovery] Restored ${restoredConfigModifies.size} pendingConfigModifies`)
+      } else {
+        this.localStorageManager.clearPending('pendingConfigModifies')
+      }
+
       // 6. 注册事件监听 (依赖哈希管理器)
       if (this.fileHashManager.isReady()) {
         this.eventManager = new EventManager(this)

--- a/src/main.ts
+++ b/src/main.ts
@@ -386,6 +386,25 @@ export default class FastSync extends Plugin {
         this.localStorageManager.clearPending('pendingConfigModifies')
       }
 
+      // 清理过期的断点续传 checkpoint（超过 20 分钟即视为过期，与服务端 session 超时一致）
+      // Clean up expired upload resume checkpoints (>20 min matches server session timeout)
+      const uploadCheckpointPrefix = `fns-${this.app.vault.getName()}-uploadSession-`
+      const expireMs = 20 * 60 * 1000
+      const now = Date.now()
+      for (let i = localStorage.length - 1; i >= 0; i--) {
+        const key = localStorage.key(i)
+        if (key && key.startsWith(uploadCheckpointPrefix)) {
+          try {
+            const cp = JSON.parse(localStorage.getItem(key) || '{}')
+            if (!cp.timestamp || now - cp.timestamp > expireMs) {
+              localStorage.removeItem(key)
+            }
+          } catch (e) {
+            localStorage.removeItem(key)
+          }
+        }
+      }
+
       // 6. 注册事件监听 (依赖哈希管理器)
       if (this.fileHashManager.isReady()) {
         this.eventManager = new EventManager(this)


### PR DESCRIPTION

## 问题背景

本 PR 修复了四类影响多端同步可靠性的问题：

1. **pending 修改 Map 未持久化**：笔记 / 附件 / 配置的待同步队列仅存于内存，插件崩溃或强制退出后队列丢失，重启后这些变更可能永久漏同步。

2. **断网重连后 `isSyncing` 永不重置**：`handleSync` 入口守卫在断网场景下无法重置，导致重连后同步流程被永久阻塞（卡死）。

3. **Folder 广播接收后未更新 `lastFolderSyncTime`**：`folder_operator` 收到 Modify / Delete / Rename 广播时未推进本地同步时间戳，仅靠 `FolderSyncEnd` 推进，导致下次 FolderSync 可能重复下发已处理的变更。

4. **分块上传无断点续传**：大文件分块上传中途断网后，重连只能从第 0 块重新开始，造成带宽浪费，服务端虽有幂等保护但体验差。
---

## 变更内容

### 1. 持久化 pending 修改 Map，防止崩溃漏同步（`src/lib/local_storage_manager.ts` 等）

- `LocalStorageManager` 新增 `savePending` / `loadPending` / `clearPending` 方法，使用独立 localStorage key（`fns-{vault}-pending*`）
- 在 `note_operator` / `file_operator` / `config_operator` 所有 pending Map 的 `set` / `delete` / `clear` 调用处同步写入 localStorage
- `main.ts` `onLayoutReady`：hashManager 初始化后恢复持久化的 pending Map，过滤本地已不存在的路径，使其豁免增量同步的 mtime 过滤

### 2. 修复断网重连后 `isSyncing` 永不重置（`src/lib/operator.ts`、`src/lib/websocket.ts`）

- `handleSync` 加 `try/finally` 确保所有退出路径（正常完成、early return、异常）都重置 `isSyncing = false`
- `websocket.ts` `onclose` 回调：断连时立即重置 `isSyncing` / `isSyncRequesting`，使重连后 `handleSync` 不被入口守卫拦截

### 3. Folder 广播接收时实时更新 `lastFolderSyncTime`（`src/lib/folder_operator.ts`）

- `receiveFolderSyncModify` / `receiveFolderSyncDelete` / `receiveFolderSyncRename` 三个函数的 `finally` 块均补充：
  ```typescript
  if (data.lastTime && data.lastTime > Number(plugin.localStorageManager.getMetadata("lastFolderSyncTime"))) {
      plugin.localStorageManager.setMetadata("lastFolderSyncTime", data.lastTime)
  }
  ```
- 与 `note_operator` / `file_operator` 的处理方式保持一致

### 4. 类型补全（`src/lib/types.ts`）

- `FileUploadMessage` 新增 `pathHash: string` 字段（对应服务端 PR 中 `FileSyncUploadMessage` 新增的 `PathHash`）
- `FolderSyncRenameMessage` 新增 `lastTime?: number` 可选字段

### 5. 分块上传断点续传（`src/lib/file_operator.ts`、`src/main.ts`）

- 每发送成功一个分块（非最后块），在 `after` 回调中写入 localStorage checkpoint：
  ```
  key:   fns-{vault}-uploadSession-{pathHash}
  value: { sessionId, lastChunkIndex, contentHash, timestamp }
  ```
- 重连后收到 `FileUpload` 消息时，若 checkpoint 中 `sessionId` 和 `contentHash` 均匹配，则从 `lastChunkIndex + 1` 继续发送，跳过已上传分块
- 以下路径均清除 checkpoint：
  - `receiveFileUploadAck`（正常完成）
  - 取消上传（`cancelled` 标志触发）
  - `catch` 块（异常退出）
- `onload` 启动时清理超过 20 分钟（与服务端 session 超时一致）或缺少 `timestamp` 的过期 checkpoint

---

## 影响范围

- 大文件分块上传的断网续传体验
- 插件崩溃 / 强制退出后的同步可靠性
- 断网重连后的同步流程恢复
- Folder 多端实时广播的增量同步时间戳推进

## 关联 PR（服务端）

需配套服务端 PR 以支持：
- `FileSyncUploadMessage` 携带 `pathHash`（断点续传 checkpoint key 所需）
- `lastTime` 时间窗口修复（保证增量同步基准时间戳的正确性）
- Folder / File / Note delete / rename 广播携带 `lastTime`