### PR TITLE
fix: 完整同步命令实际执行增量同步的问题

### DIFF
--- a/src/lib/operator.ts
+++ b/src/lib/operator.ts
@@ -16,7 +16,7 @@ export const startupSync = (plugin: FastSync): void => {
   void handleSync(plugin, plugin.localStorageManager.getMetadata("isInitSync"));
 };
 export const startupFullSync = async (plugin: FastSync) => {
-  void handleSync(plugin);
+  void handleSync(plugin, false);
 };
 
 export const resetSettingSyncTime = async (plugin: FastSync) => {


### PR DESCRIPTION
## 问题

"完整同步"命令（命令面板中的 `Fast Sync: 完整同步`，或 `start-full-sync` 命令）实际执行的是**增量同步**而非全量同步，导致用户点击完整同步后显示"新笔记0"但服务端有大量笔记（Issue #145）。

## 根因

重构（commit `9619b9d`）将同步逻辑从 `syncAllFilesImpl` 迁移到 `handleSync` 时，`startupFullSync` 调用 `handleSync(plugin)` 未传第二个参数 `isLoadLastTime`。

`handleSync` 的签名是：
```ts
handleSync(plugin: FastSync, isLoadLastTime: boolean = true, syncMode: SyncMode = "auto")
```

默认 `isLoadLastTime = true`，意味着会加载上次同步时间并跳过 mtime 未变的已追踪文件 —— 这正是**增量同步**的行为。

重构前的旧代码（`syncAllFilesImpl`）会显式设置 `plugin.settings.lastSyncTime = 0` 来强制全量比较，重构后这个关键行为丢失了。

## 修复

```diff
- void handleSync(plugin);
+ void handleSync(plugin, false);
```

传递 `isLoadLastTime = false` 后，`handleSync` 会：
1. 设置 `currentSyncType = 'full'`（而非 'incremental'）
2. 跳过所有基于 `lastSyncTime` 的文件过滤条件
3. 对 vault 中所有文件计算哈希并与服务端完整比较

## 影响范围

仅影响用户主动触发的"完整同步"命令。启动时的自动同步（`startupSync`）通过 `getMetadata("isInitSync")` 正确判断首次/增量，不受影响。

## 关联 Issue

Closes #145（点击完整同步没反应 — 实际是增量同步跳过了所有文件）
