### PR TITLE
修复同步结束时的 Renderer OOM

### DIFF
--- a/src/lib/config_hash_manager.ts
+++ b/src/lib/config_hash_manager.ts
@@ -174,6 +174,16 @@ export class ConfigHashManager {
         this.saveToStorage();
     }
 
+    setFileHashes(entries: Iterable<[string, string]>, getStat?: (path: string) => { mtime?: number; size?: number } | null | undefined): void {
+        let changed = false;
+        for (const [path, hash] of entries) {
+            const stat = getStat?.(path);
+            this.hashMap.set(path, { hash, mtime: stat?.mtime || 0, size: stat?.size || 0 });
+            changed = true;
+        }
+        if (changed) this.saveToStorage();
+    }
+
     /**
      * 删除指定路径的哈希
      */
@@ -182,6 +192,14 @@ export class ConfigHashManager {
         if (deleted) {
             this.saveToStorage();
         }
+    }
+
+    removeFileHashes(paths: Iterable<string>): void {
+        let changed = false;
+        for (const path of paths) {
+            changed = this.hashMap.delete(path) || changed;
+        }
+        if (changed) this.saveToStorage();
     }
 
     /**
@@ -303,4 +321,3 @@ export class ConfigHashManager {
         };
     }
 }
-

--- a/src/lib/file_hash_manager.ts
+++ b/src/lib/file_hash_manager.ts
@@ -1,6 +1,6 @@
 import { TFile } from "obsidian";
 
-import { hashContent, hashContentAsync, hashArrayBuffer, dump, isPathExcluded, showSyncNotice } from "./helps";
+import { hashContent, hashContentAsync, hashArrayBuffer, dump, isPathExcluded, showSyncNotice, isLargeBinarySyncRisk, describeBinarySyncLimit, logMemorySnapshot, isBinaryFileSyncDisabled } from "./helps";
 import type FastSync from "../main";
 
 
@@ -85,10 +85,20 @@ export class FileHashManager {
             contentHash = await hashContentAsync(content);
             content = null; // 显式释放引用 (Explicitly release reference)
           } else {
+            if (isBinaryFileSyncDisabled()) {
+              dump(`FileHashManager: skip binary hash while binary sync is disabled: ${file.path}`);
+              continue;
+            }
+            if (isLargeBinarySyncRisk(file.stat.size)) {
+              dump(`FileHashManager: skip large binary hash (${describeBinarySyncLimit()} limit): ${file.path}`, file.stat.size);
+              continue;
+            }
             // 非 md 文件使用二进制内容计算哈希
+            logMemorySnapshot(`before hash ${file.path}`);
             let buffer: ArrayBuffer | null = await this.plugin.app.vault.readBinary(file);
             contentHash = await hashArrayBuffer(buffer);
             buffer = null; // 显式释放引用 (Explicitly release reference)
+            logMemorySnapshot(`after hash ${file.path}`);
           }
 
           this.hashMap.set(file.path, {
@@ -161,6 +171,16 @@ export class FileHashManager {
     this.saveToStorage();
   }
 
+  setFileHashes(entries: Iterable<[string, string]>, getStat?: (path: string) => { mtime?: number; size?: number } | null | undefined): void {
+    let changed = false;
+    for (const [path, hash] of entries) {
+      const stat = getStat?.(path);
+      this.hashMap.set(path, { hash, mtime: stat?.mtime || 0, size: stat?.size || 0 });
+      changed = true;
+    }
+    if (changed) this.saveToStorage();
+  }
+
   /**
    * 删除指定路径的哈希
    */
@@ -169,6 +189,14 @@ export class FileHashManager {
     if (deleted) {
       this.saveToStorage();
     }
+  }
+
+  removeFileHashes(paths: Iterable<string>): void {
+    let changed = false;
+    for (const path of paths) {
+      changed = this.hashMap.delete(path) || changed;
+    }
+    if (changed) this.saveToStorage();
   }
 
   /**
@@ -295,4 +323,3 @@ export class FileHashManager {
     };
   }
 }
-

--- a/src/lib/file_operator.ts
+++ b/src/lib/file_operator.ts
@@ -1,7 +1,7 @@
 import { TFile, TAbstractFile, Notice, normalizePath, Platform } from "obsidian";
 
 import { ReceiveMessage, ReceiveFileSyncUpdateMessage, FileUploadMessage, FileSyncChunkDownloadMessage, FileDownloadSession, ReceiveMtimeMessage, ReceivePathMessage, SyncEndData } from "./types";
-import { hashContent, hashArrayBuffer, getPluginDir, dump, sleep, dumpTable, isPathExcluded, getSafeCtime } from "./helps";
+import { hashContent, hashArrayBuffer, getPluginDir, dump, sleep, dumpTable, isPathExcluded, getSafeCtime, isLargeBinarySyncRisk, describeBinarySyncLimit, showSyncNotice, logMemorySnapshot, isBinaryFileSyncDisabled } from "./helps";
 import { FileCloudPreview } from "./file_cloud_preview";
 import { SyncLogManager } from "./sync_log_manager";
 import { HttpApiService } from "./api";
@@ -63,6 +63,15 @@ export const fileModify = async function (file: TAbstractFile, plugin: FastSync,
   if (eventEnter && !plugin.getWatchEnabled()) return
   if (eventEnter && plugin.isIgnoredFile(file.path)) return
   if (isPathExcluded(file.path, plugin)) return
+  if (isBinaryFileSyncDisabled()) {
+    dump(`Skip file modify while binary sync is disabled: ${file.path}`)
+    return
+  }
+  if (isLargeBinarySyncRisk(file.stat.size)) {
+    dump(`Skip file modify for large attachment (${describeBinarySyncLimit()} limit): ${file.path}`, file.stat.size)
+    showSyncNotice(`Fast Note Sync skipped large file: ${file.path}`, 5000)
+    return
+  }
 
   await plugin.lockManager.withLock(file.path, async () => {
     plugin.addIgnoredFile(file.path)
@@ -80,8 +89,11 @@ export const fileModify = async function (file: TAbstractFile, plugin: FastSync,
           return
         }
       } else {
+        logMemorySnapshot(`before modify read ${file.path}`)
         content = await plugin.app.vault.readBinary(file)
         contentHash = await hashArrayBuffer(content)
+        content = null
+        logMemorySnapshot(`after modify hash ${file.path}`)
       }
 
       const data = {
@@ -121,6 +133,7 @@ export const fileDelete = async function (file: TAbstractFile, plugin: FastSync,
   if (eventEnter && !plugin.getWatchEnabled()) return
   if (eventEnter && plugin.isIgnoredFile(file.path)) return
   if (isPathExcluded(file.path, plugin)) return
+  if (isBinaryFileSyncDisabled()) return
 
   // --- 新增：删除拦截 ---
   if (plugin.lastSyncPathDeleted.has(file.path)) {
@@ -173,6 +186,7 @@ export const fileDeleteByPath = async function (filePath: string, plugin: FastSy
   if (plugin.settings.syncEnabled == false || plugin.settings.readonlySyncEnabled) return
   if (filePath.endsWith(".md")) return
   if (isPathExcluded(filePath, plugin)) return
+  if (isBinaryFileSyncDisabled()) return
   if (plugin.lastSyncPathDeleted.has(filePath)) return
 
   await plugin.lockManager.withLock(filePath, async () => {
@@ -219,6 +233,7 @@ export const fileRename = async function (file: TAbstractFile, oldfile: string, 
   if (!plugin.getWatchEnabled() && eventEnter) return
   if (plugin.isIgnoredFile(file.path) && eventEnter) return
   if (isPathExcluded(file.path, plugin)) return
+  if (isBinaryFileSyncDisabled()) return
   if (!(file instanceof TFile)) return
 
   // --- 新增：重命名拦截 ---
@@ -245,6 +260,10 @@ export const fileRename = async function (file: TAbstractFile, oldfile: string, 
           // 尝试新路径哈希缓存 (Try new path cache)
           contentHash = plugin.fileHashManager.getValidHash(file.path, file.stat.mtime, file.stat.size);
           if (contentHash == null) {
+            if (isLargeBinarySyncRisk(file.stat.size)) {
+              dump(`Skip rename hash for large attachment (${describeBinarySyncLimit()} limit): ${file.path}`, file.stat.size)
+              return
+            }
             const content: ArrayBuffer = await plugin.app.vault.readBinary(file)
             contentHash = await hashArrayBuffer(content)
           }
@@ -275,6 +294,11 @@ export const fileRename = async function (file: TAbstractFile, oldfile: string, 
  */
 export const receiveFileUpload = async function (data: FileUploadMessage, plugin: FastSync) {
   if (plugin.settings.syncEnabled == false) return
+  if (isBinaryFileSyncDisabled()) {
+    dump(`Skip file upload request while binary sync is disabled: ${data.path}`)
+    plugin.fileSyncTasks.completed++
+    return
+  }
   if (plugin.settings.readonlySyncEnabled) {
     dump(`Read-only mode: Intercepted file upload request for ${data.path}`)
     plugin.fileSyncTasks.completed++
@@ -289,6 +313,12 @@ export const receiveFileUpload = async function (data: FileUploadMessage, plugin
   const file = plugin.app.vault.getFileByPath(normalizePath(data.path))
   if (!file) {
     dump(`File not found for upload: ${data.path} `)
+    plugin.fileSyncTasks.completed++
+    return
+  }
+  if (isLargeBinarySyncRisk(file.stat.size)) {
+    dump(`Skip file upload for large attachment (${describeBinarySyncLimit()} limit): ${data.path}`, file.stat.size)
+    showSyncNotice(`Fast Note Sync skipped large file upload: ${data.path}`, 5000)
     plugin.fileSyncTasks.completed++
     return
   }
@@ -309,6 +339,7 @@ export const receiveFileUpload = async function (data: FileUploadMessage, plugin
       // 延迟到任务排到时才读取文件内容, 减少内存积压
       let content: ArrayBuffer | null = null;
       try {
+        logMemorySnapshot(`before upload read ${data.path}`)
         content = await plugin.app.vault.readBinary(file)
       } catch (e) {
         dump(`Failed to read file for upload: ${data.path}`, e)
@@ -319,6 +350,7 @@ export const receiveFileUpload = async function (data: FileUploadMessage, plugin
       }
 
       const contentHash = await hashArrayBuffer(content)
+      logMemorySnapshot(`after upload hash ${data.path}`)
       // 将 hash 暂存到 pending map，等待服务端 FileUploadAck 后再写入 hashManager
       // Temporarily store hash in pending map, update hashManager only after server FileUploadAck
       plugin.pendingUploadHashes.set(data.path, contentHash)
@@ -507,10 +539,21 @@ export const receiveFileUpload = async function (data: FileUploadMessage, plugin
  */
 export const receiveFileSyncUpdate = async function (data: ReceiveFileSyncUpdateMessage, plugin: FastSync) {
   if (plugin.settings.syncEnabled == false) return
+  if (isBinaryFileSyncDisabled()) {
+    dump(`Skip file sync update while binary sync is disabled: ${data.path}`)
+    plugin.fileSyncTasks.completed++;
+    return
+  }
   // 服务端推送说明该路径已有新内容，清除可能残留的 deleteAck pending 防止 Ack 删除新 hash
   // Server push means path has new content; clear stale deleteAck pending to protect newly-written hash
   plugin.pendingFileDeleteAcks.delete(data.path)
   if (isPathExcluded(data.path, plugin)) {
+    plugin.fileSyncTasks.completed++;
+    return
+  }
+  if (isLargeBinarySyncRisk(data.size)) {
+    dump(`Skip file download for large attachment (${describeBinarySyncLimit()} limit): ${data.path}`, data.size)
+    showSyncNotice(`Fast Note Sync skipped large file download: ${data.path}`, 5000)
     plugin.fileSyncTasks.completed++;
     return
   }
@@ -584,6 +627,10 @@ export const receiveFileSyncUpdate = async function (data: ReceiveFileSyncUpdate
  */
 export const receiveFileSyncDelete = async function (data: ReceivePathMessage, plugin: FastSync) {
   if (plugin.settings.syncEnabled == false) return
+  if (isBinaryFileSyncDisabled()) {
+    plugin.fileSyncTasks.completed++;
+    return
+  }
   if (isPathExcluded(data.path, plugin)) {
     plugin.fileSyncTasks.completed++;
     return
@@ -640,6 +687,10 @@ export const receiveFileSyncDelete = async function (data: ReceivePathMessage, p
  */
 export const receiveFileSyncMtime = async function (data: ReceiveMtimeMessage, plugin: FastSync) {
   if (plugin.settings.syncEnabled == false) return
+  if (isBinaryFileSyncDisabled()) {
+    plugin.fileSyncTasks.completed++;
+    return
+  }
   if (isPathExcluded(data.path, plugin)) {
     plugin.fileSyncTasks.completed++;
     return
@@ -666,6 +717,14 @@ export const receiveFileSyncMtime = async function (data: ReceiveMtimeMessage, p
   await plugin.lockManager.withLock(normalizedPath, async () => {
     const file = plugin.app.vault.getFileByPath(normalizedPath)
     if (file) {
+      if (isLargeBinarySyncRisk(file.stat.size)) {
+        dump(`Skip binary mtime rewrite for large attachment (${describeBinarySyncLimit()} limit): ${normalizedPath}`, file.stat.size)
+        plugin.lastSyncMtime.set(data.path, data.mtime)
+        if (data.lastTime && data.lastTime > Number(plugin.localStorageManager.getMetadata("lastFileSyncTime"))) {
+          plugin.localStorageManager.setMetadata("lastFileSyncTime", data.lastTime)
+        }
+        return
+      }
       const content = await plugin.app.vault.readBinary(file)
       plugin.addIgnoredFile(normalizedPath)
       try {
@@ -692,6 +751,7 @@ export const receiveFileSyncMtime = async function (data: ReceiveMtimeMessage, p
  */
 export const receiveFileSyncChunkDownload = async function (data: FileSyncChunkDownloadMessage, plugin: FastSync) {
   if (plugin.settings.syncEnabled == false) return
+  if (isBinaryFileSyncDisabled()) return
   dump(`Receive file chunk download: `, data.path, data.sessionId, `totalChunks: ${data.totalChunks}`)
 
   // 打印下载信息表格
@@ -839,6 +899,7 @@ export const checkAndUploadAttachments = async function (plugin: FastSync) {
  */
 export const handleFileChunkDownload = async function (buf: ArrayBuffer | Blob, plugin: FastSync) {
   if (plugin.settings.syncEnabled == false) return
+  if (isBinaryFileSyncDisabled()) return
   const binaryData = buf instanceof Blob ? await buf.arrayBuffer() : buf
   if (binaryData.byteLength < 40) return
 
@@ -888,6 +949,10 @@ export const handleFileChunkDownload = async function (buf: ArrayBuffer | Blob, 
  */
 export const receiveFileSyncRename = async function (data: any, plugin: FastSync) {
   if (plugin.settings.syncEnabled == false) return
+  if (isBinaryFileSyncDisabled()) {
+    plugin.fileSyncTasks.completed++;
+    return
+  }
   if (isPathExcluded(data.path, plugin) || isPathExcluded(data.oldPath, plugin)) {
     plugin.fileSyncTasks.completed++;
     return
@@ -918,8 +983,12 @@ export const receiveFileSyncRename = async function (data: any, plugin: FastSync
         if (data.mtime) {
           const renamedFile = plugin.app.vault.getFileByPath(normalizedNewPath)
           if (renamedFile instanceof TFile) {
-            const content = await plugin.app.vault.readBinary(renamedFile)
-            await plugin.app.vault.modifyBinary(renamedFile, content, { ...(data.ctime > 0 && { ctime: data.ctime }), ...(data.mtime > 0 && { mtime: data.mtime }) })
+            if (isLargeBinarySyncRisk(renamedFile.stat.size)) {
+              dump(`Skip renamed binary mtime rewrite for large attachment (${describeBinarySyncLimit()} limit): ${normalizedNewPath}`, renamedFile.stat.size)
+            } else {
+              const content = await plugin.app.vault.readBinary(renamedFile)
+              await plugin.app.vault.modifyBinary(renamedFile, content, { ...(data.ctime > 0 && { ctime: data.ctime }), ...(data.mtime > 0 && { mtime: data.mtime }) })
+            }
           }
         }
 
@@ -944,6 +1013,11 @@ export const receiveFileSyncRename = async function (data: any, plugin: FastSync
       if (targetFile instanceof TFile) {
         const sizeMatch = data.size === undefined || targetFile.stat.size === data.size
         if (sizeMatch) {
+          if (isLargeBinarySyncRisk(targetFile.stat.size)) {
+            dump(`Skip rename target hash for large attachment (${describeBinarySyncLimit()} limit): ${data.path}`, targetFile.stat.size)
+            plugin.fileSyncTasks.completed++
+            return
+          }
           const content = await plugin.app.vault.readBinary(targetFile)
           const localContentHash = await hashArrayBuffer(content)
           if (localContentHash === data.contentHash) {
@@ -978,6 +1052,12 @@ export const receiveFileSyncRename = async function (data: any, plugin: FastSync
 const handleFileChunkDownloadComplete = async function (session: FileDownloadSession, plugin: FastSync) {
   const slotKey = `download_${session.path}`;
   try {
+    if (isLargeBinarySyncRisk(session.size)) {
+      dump(`Skip assembling large downloaded attachment (${describeBinarySyncLimit()} limit): ${session.path}`, session.size)
+      plugin.fileDownloadSessions.delete(session.sessionId)
+      if (session.tempDir) await clearTempChunksDir(plugin, session.sessionId)
+      return
+    }
     const chunks: ArrayBuffer[] = []
     for (let i = 0; i < session.totalChunks; i++) {
       let chunk: ArrayBuffer | undefined;
@@ -1135,4 +1215,3 @@ export const receiveFileDeleteAck = function (data: { lastTime?: number; path?: 
     plugin.concurrencyManager.releaseSlot(data.path)
   }
 }
-

--- a/src/lib/helps.ts
+++ b/src/lib/helps.ts
@@ -395,6 +395,35 @@ export const hashArrayBuffer = async function (buffer: ArrayBuffer): Promise<str
   return result
 }
 
+export const MAX_IN_MEMORY_FILE_SYNC_BYTES = 128 * 1024 * 1024
+export const BINARY_FILE_SYNC_ENABLED = true
+
+export const isBinaryFileSyncDisabled = function (): boolean {
+  return !BINARY_FILE_SYNC_ENABLED
+}
+
+export const isLargeBinarySyncRisk = function (size: number): boolean {
+  return typeof size === "number" && size > MAX_IN_MEMORY_FILE_SYNC_BYTES
+}
+
+export const describeBinarySyncLimit = function (): string {
+  return formatFileSize(MAX_IN_MEMORY_FILE_SYNC_BYTES)
+}
+
+export const logMemorySnapshot = function (label: string): void {
+  if (!isLogEnabled) return
+  const memory = (performance as any)?.memory
+  if (memory) {
+    console.log("[FastNoteSync][Memory]", label, {
+      used: formatFileSize(memory.usedJSHeapSize),
+      total: formatFileSize(memory.totalJSHeapSize),
+      limit: formatFileSize(memory.jsHeapSizeLimit),
+    })
+  } else {
+    console.log("[FastNoteSync][Memory]", label)
+  }
+}
+
 /**
  * 获取安全的 ctime (如果不存在则回退到 mtime)
  */

--- a/src/lib/operator.ts
+++ b/src/lib/operator.ts
@@ -5,7 +5,7 @@ import { receiveConfigSyncModify, receiveConfigUpload, receiveConfigSyncMtime, r
 import { receiveNoteSyncModify, receiveNoteUpload, receiveNoteSyncMtime, receiveNoteSyncDelete, receiveNoteSyncEnd, receiveNoteSyncRename, receiveNoteModifyAck, receiveNoteRenameAck, receiveNoteDeleteAck } from "./note_operator";
 import { SyncMode, SnapFile, SnapFolder, SyncEndData, PathHashFile, NoteSyncData, FileSyncData, ConfigSyncData, FolderSyncData } from "./types";
 import { receiveFolderSyncModify, receiveFolderSyncDelete, receiveFolderSyncRename, receiveFolderSyncEnd } from "./folder_operator";
-import { hashContent, hashContentAsync, hashArrayBuffer, dump, isPathExcluded, configIsPathExcluded, getConfigSyncCustomDirs, generateUUID, showSyncNotice } from "./helps";
+import { hashContent, hashContentAsync, hashArrayBuffer, dump, isPathExcluded, configIsPathExcluded, getConfigSyncCustomDirs, generateUUID, showSyncNotice, isLargeBinarySyncRisk, describeBinarySyncLimit, logMemorySnapshot, isBinaryFileSyncDisabled } from "./helps";
 import { FileCloudPreview } from "./file_cloud_preview";
 import { SyncLogManager } from "./sync_log_manager";
 import type FastSync from "../main";
@@ -266,21 +266,17 @@ async function receiveSyncEndWrapper(data: any, plugin: FastSync, type: "note" |
   // 2. SyncEnd 到达说明服务端已处理本轮同步（含删除），将 pending 删除路径从 hashManager 移除
   // SyncEnd means server processed this sync round (including deletes); remove pending delete paths from hashManager
   if (type === "note") {
-    for (const path of plugin.pendingDeleteNotePaths) plugin.fileHashManager.removeFileHash(path)
+    plugin.fileHashManager.removeFileHashes(plugin.pendingDeleteNotePaths)
     plugin.pendingDeleteNotePaths.clear()
     // 同步结束，提交本轮同步中可能产生的待确认上传 hash
-    for (const [path, hash] of plugin.pendingNoteModifies) {
-      plugin.fileHashManager.setFileHash(path, hash)
-    }
+    plugin.fileHashManager.setFileHashes(plugin.pendingNoteModifies, (path) => plugin.app.vault.getFileByPath(path)?.stat)
     plugin.pendingNoteModifies.clear()
     plugin.localStorageManager.clearPending('pendingNoteModifies')
   } else if (type === "file") {
-    for (const path of plugin.pendingDeleteFilePaths) plugin.fileHashManager.removeFileHash(path)
+    plugin.fileHashManager.removeFileHashes(plugin.pendingDeleteFilePaths)
     plugin.pendingDeleteFilePaths.clear()
     // 同步结束，提交本轮同步中可能产生的待确认上传 hash
-    for (const [path, hash] of plugin.pendingUploadHashes) {
-      plugin.fileHashManager.setFileHash(path, hash)
-    }
+    plugin.fileHashManager.setFileHashes(plugin.pendingUploadHashes, (path) => plugin.app.vault.getFileByPath(path)?.stat)
     plugin.pendingUploadHashes.clear()
     plugin.localStorageManager.clearPending('pendingUploadHashes')
   } else if (type === "folder") {
@@ -288,11 +284,9 @@ async function receiveSyncEndWrapper(data: any, plugin: FastSync, type: "note" |
     plugin.pendingDeleteFolderPaths.clear()
   } else if (type === "config") {
     if (plugin.configHashManager && plugin.configHashManager.isReady()) {
-      for (const path of plugin.pendingDeleteConfigPaths) plugin.configHashManager.removeFileHash(path)
+      plugin.configHashManager.removeFileHashes(plugin.pendingDeleteConfigPaths)
       // 同步结束，提交本轮同步中可能产生的待确认上传 hash
-      for (const [path, hash] of plugin.pendingConfigModifies) {
-        plugin.configHashManager.setFileHash(path, hash)
-      }
+      plugin.configHashManager.setFileHashes(plugin.pendingConfigModifies)
     }
     plugin.pendingDeleteConfigPaths.clear()
     plugin.pendingConfigModifies.clear()
@@ -509,6 +503,14 @@ export const handleSync = async function (plugin: FastSync, isLoadLastTime: bool
 
           notes.push(item);
         } else {
+          if (isBinaryFileSyncDisabled()) {
+            dump(`Skip scanning attachment while binary sync is disabled: ${file.path}`);
+            continue;
+          }
+          if (isLargeBinarySyncRisk(file.stat.size)) {
+            dump(`Skip scanning large attachment (${describeBinarySyncLimit()} limit): ${file.path}`, file.stat.size);
+            continue;
+          }
           const skipSync = plugin.settings.cloudPreviewEnabled && (!plugin.settings.cloudPreviewTypeRestricted || FileCloudPreview.isRestrictedType("." + file.extension));
           if (skipSync) continue;
 
@@ -522,7 +524,11 @@ export const handleSync = async function (plugin: FastSync, isLoadLastTime: bool
           // 尝试从缓存获取有效的哈希，避免重复计算 (Try to get valid hash from cache)
           let contentHash = plugin.fileHashManager.getValidHash(file.path, file.stat.mtime, file.stat.size);
           if (contentHash === null) {
-            contentHash = await hashArrayBuffer(await plugin.app.vault.readBinary(file));
+            logMemorySnapshot(`before scan hash ${file.path}`);
+            let content: ArrayBuffer | null = await plugin.app.vault.readBinary(file);
+            contentHash = await hashArrayBuffer(content);
+            content = null;
+            logMemorySnapshot(`after scan hash ${file.path}`);
           }
 
           let item = {
@@ -630,11 +636,17 @@ export const handleSync = async function (plugin: FastSync, isLoadLastTime: bool
     const fullPath = normalizePath(path);
     const stat = await plugin.app.vault.adapter.stat(fullPath);
     if (!stat) continue;
+    if (isLargeBinarySyncRisk(stat.size)) {
+      dump(`Skip scanning large config file (${describeBinarySyncLimit()} limit): ${path}`, stat.size);
+      continue;
+    }
     if (isLoadLastTime && stat.mtime < Number(plugin.localStorageManager.getMetadata("lastConfigSyncTime"))) continue;
     // 尝试从缓存获取有效的哈希 (Try to get valid hash from cache)
     let contentHash = plugin.configHashManager.getValidHash(path, stat.mtime, stat.size);
     if (contentHash === null) {
-      contentHash = await hashArrayBuffer(await plugin.app.vault.adapter.readBinary(fullPath));
+      let content: ArrayBuffer | null = await plugin.app.vault.adapter.readBinary(fullPath);
+      contentHash = await hashArrayBuffer(content);
+      content = null;
     }
 
     configs.push({
@@ -829,7 +841,7 @@ export const handleRequestSend = async function (plugin: FastSync, syncMode: Syn
 
     // 如果启用了云预览且未开启类型限制，则不发送 FileSync 请求，从而关闭启动时的 file 同步
     // 若开启了类型限制，则需要发送以同步不受限类型的附件1
-    if (!plugin.settings.cloudPreviewEnabled || plugin.settings.cloudPreviewTypeRestricted) {
+    if (!isBinaryFileSyncDisabled() && (!plugin.settings.cloudPreviewEnabled || plugin.settings.cloudPreviewTypeRestricted)) {
       plugin.websocket.SendMessage("FileSync", fileSyncData);
     }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -401,11 +401,12 @@ export default class FastSync extends Plugin {
       // 清理过期的断点续传 checkpoint（超过 20 分钟即视为过期，与服务端 session 超时一致）
       // Clean up expired upload resume checkpoints (>20 min matches server session timeout)
       const uploadCheckpointPrefix = `fns-${this.app.vault.getName()}-uploadSession-`
+      const anyUploadCheckpointPattern = /^fns-.+-uploadSession-/
       const expireMs = 20 * 60 * 1000
       const now = Date.now()
       for (let i = localStorage.length - 1; i >= 0; i--) {
         const key = localStorage.key(i)
-        if (key && key.startsWith(uploadCheckpointPrefix)) {
+        if (key && (key.startsWith(uploadCheckpointPrefix) || anyUploadCheckpointPattern.test(key))) {
           try {
             const cp = JSON.parse(localStorage.getItem(key) || '{}')
             if (!cp.timestamp || now - cp.timestamp > expireMs) {
@@ -611,6 +612,13 @@ export default class FastSync extends Plugin {
 
   async refreshRuntime(forceRegister: boolean = true, setItem: string = "") {
     if (forceRegister && this.settings.api && this.settings.apiToken) {
+      if (this.settings.manualSyncEnabled) {
+        dump("Manual sync mode enabled, skipping automatic WebSocket registration")
+        this.websocket?.unRegister()
+        this.isWatchEnabled = false
+        this.updateStatusBar("")
+        return
+      }
       // 1. 前置探测跳转，更新 runApi
       await this.api?.probeApiRedirect()
 


### PR DESCRIPTION
## 这次修了什么

修复一次同步结束时可能触发 Obsidian Renderer OOM 的问题。

## 为什么会 OOM

同步结束收到 `NoteSyncEnd` / `FileSyncEnd` / `SettingSyncEnd` 后，插件会把本轮 pending 的 hash 写回本地缓存。

之前的逻辑是：每处理一个文件，就保存一次整个 hash map 到 `localStorage`。

当笔记库文件很多时，`fileHashMap` 本身已经很大。几千个文件会触发几千次 `JSON.stringify + localStorage.setItem`，Renderer 会产生大量临时字符串和内存峰值，严重时直接 OOM 崩溃。

## 怎么修

- 给 note/file/config hash manager 增加批量更新和批量删除方法。
- `SyncEnd` 时批量提交 pending hash，只保存一次 `localStorage`。
- 附件和配置扫描时避免嵌套 `await readBinary(...)`，hash 完显式释放大 `ArrayBuffer` 引用。
- 给过大的附件/配置文件增加内存保护，避免一次性读入超大文件导致 Renderer 爆内存。
- 手动同步模式下不再自动注册 WebSocket，避免开启手动模式仍自动同步。
- 清理过期上传 checkpoint 时兼容旧 vault 名残留 key。

## 验证

- `pnpm run build` 通过。
- 在一个约 6600+ 笔记、1000+ 附件的 vault 上启动 Obsidian 测试。
- 修复前 Renderer 内存会冲到 6GB+ 并崩溃。
- 修复后完整 note/config/file sync 可完成；包含一个约 72MB 的 mp4 附件时，峰值约 1.3GB，之后回落，没有新增 Renderer crash report。

