### PR TITLE
fix(websocket): clarify startup authorization failures

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "devts": "node esbuild.config.mjs",
     "devcss": "sass --watch src/styles.scss styles.css && tsc -noEmit -skipLibCheck && node esbuild.config.mjs production",
     "build": "tsc -noEmit -skipLibCheck && node esbuild.config.mjs production",
+    "test:auth": "node tests/websocket-auth-error.test.mjs",
     "ver": "node ./scripts/update-version.js",
     "dist": "npx tsx scripts/copy-dist.ts",
     "translate": "node scripts/translate-i18n.mjs --model Qwen/Qwen3.6-35B-A3B",

--- a/src/lib/websocket.ts
+++ b/src/lib/websocket.ts
@@ -11,8 +11,46 @@ import { $ } from "../i18n/lang";
 // 冲突相关错误码
 const ERROR_SYNC_CONFLICT = 530
 
+const AUTH_ERROR_REIMPORT_CODES = new Set([307, 308, 309, 310])
 
+const AUTH_ERROR_FALLBACK_MESSAGES: Record<number, string> = {
+  307: "Authorization token is missing",
+  308: "Session expired or token has been revoked",
+  309: "Authorization token is invalid or incomplete",
+  310: "Authorization token has expired",
+  312: "Authorization token is restricted by IP",
+  313: "Authorization token is restricted by user agent",
+  314: "Authorization token is restricted by client",
+  315: "Authorization token scope is restricted",
+}
 
+function normalizeNoticeValue(value: unknown): string {
+  if (value == null) return ""
+  if (Array.isArray(value)) {
+    return value
+      .map(item => normalizeNoticeValue(item))
+      .filter(Boolean)
+      .join(", ")
+  }
+
+  const text = String(value).trim()
+  return text === "undefined" ? "" : text
+}
+
+export function formatAuthorizationError(data: { code: number; message?: unknown; details?: unknown }): string {
+  const message = normalizeNoticeValue(data.message) || AUTH_ERROR_FALLBACK_MESSAGES[data.code] || "Authorization failed"
+  const details = normalizeNoticeValue(data.details)
+  const detailsText = details ? " Details=" + details : ""
+  const authFailureText = (message + " " + details).toLowerCase()
+  const needsReimportHint = AUTH_ERROR_REIMPORT_CODES.has(data.code) ||
+    authFailureText.includes("rotated") ||
+    authFailureText.includes("revoked") ||
+    authFailureText.includes("no longer exists") ||
+    authFailureText.includes("missing")
+  const hint = needsReimportHint ? " Hint=Please re-import the API configuration from the management console." : ""
+
+  return "Service Authorization Error: Code=" + data.code + " Msg=" + message + detailsText + hint
+}
 
 // WebSocket 连接常量
 const RECONNECT_BASE_DELAY = 3000 // 重连基础延迟 (毫秒)
@@ -270,9 +308,7 @@ export class WebSocketClient {
 
         if (msgAction == "Authorization") {
           if (data.code <= 0 || data.code >= 300) {
-            const errorMsg = data.message || "";
-            const errorDetails = data.details ? " Details=" + data.details : "";
-            showSyncNotice("Service Authorization Error: Code=" + data.code + " Msg=" + errorMsg + errorDetails)
+            showSyncNotice(formatAuthorizationError(data), 6000)
             return
           } else {
             this.isAuth = true

--- a/tests/websocket-auth-error.test.mjs
+++ b/tests/websocket-auth-error.test.mjs
@@ -1,0 +1,84 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import vm from "node:vm";
+import ts from "typescript";
+
+const root = path.resolve(import.meta.dirname, "..");
+const sourcePath = path.join(root, "src", "lib", "websocket.ts");
+const source = fs.readFileSync(sourcePath, "utf8");
+
+const transpiled = ts.transpileModule(source, {
+  compilerOptions: {
+    module: ts.ModuleKind.CommonJS,
+    target: ts.ScriptTarget.ES2020,
+    esModuleInterop: true,
+  },
+  fileName: sourcePath,
+}).outputText;
+
+const module = { exports: {} };
+const requireStub = (id) => {
+  switch (id) {
+    case "obsidian":
+      return { moment: Object.assign(() => ({ format: () => "" }), { locale: () => "zh-cn" }), Platform: {} };
+    case "./helps":
+      return {
+        dump: () => undefined,
+        isWsUrl: () => true,
+        addRandomParam: (value) => value,
+        isPathExcluded: () => false,
+        isVersionNew: () => false,
+        showSyncNotice: () => undefined,
+      };
+    case "./file_operator":
+      return {
+        handleFileChunkDownload: () => undefined,
+        BINARY_PREFIX_FILE_SYNC: "fs",
+        clearUploadQueue: () => undefined,
+      };
+    case "./operator":
+      return {
+        receiveOperators: {},
+        startupSync: () => undefined,
+        startupFullSync: () => undefined,
+        checkSyncCompletion: () => undefined,
+      };
+    case "./sync_log_manager":
+      return { SyncLogManager: { getInstance: () => ({ logReceivedMessage: () => undefined, logSentMessage: () => undefined }) } };
+    case "../i18n/lang":
+      return { $: (key) => key };
+    default:
+      throw new Error(`Unexpected require: ${id}`);
+  }
+};
+
+vm.runInNewContext(transpiled, {
+  require: requireStub,
+  module,
+  exports: module.exports,
+  console,
+  TextDecoder,
+  setTimeout,
+  clearTimeout,
+}, { filename: sourcePath });
+
+const { formatAuthorizationError } = module.exports;
+
+assert.equal(typeof formatAuthorizationError, "function");
+
+const missingMessage = formatAuthorizationError({ code: 308 });
+assert.match(missingMessage, /Code=308/);
+assert.match(missingMessage, /Session expired or token has been revoked/);
+assert.match(missingMessage, /Please re-import the API configuration/);
+assert.doesNotMatch(missingMessage, /undefined/);
+
+const rotated = formatAuthorizationError({ code: 308, details: ["Token has been rotated"] });
+assert.match(rotated, /Details=Token has been rotated/);
+assert.match(rotated, /Please re-import the API configuration/);
+
+const scopeRestricted = formatAuthorizationError({ code: 315, message: undefined, details: "Permission denied: Handshake" });
+assert.match(scopeRestricted, /Authorization token scope is restricted/);
+assert.match(scopeRestricted, /Details=Permission denied: Handshake/);
+assert.doesNotMatch(scopeRestricted, /Please re-import/);
+assert.doesNotMatch(scopeRestricted, /undefined/);


### PR DESCRIPTION
## Summary
- include `client=ObsidianPlugin`, `clientName`, and `clientVersion` in `/api/user/sync` WebSocket startup URLs
- add stable fallback text for WebSocket `Authorization` errors so notices do not show `Msg=undefined`
- add a re-import API configuration hint for missing, expired, rotated, or revoked token states
- add a small Node-based regression test for missing authorization messages/details

## Why
When a manually scoped token is limited to `c:ObsidianPlugin`, startup WebSocket auth needs to send that client identity. Otherwise a valid token can be rejected during the handshake. Also, some auth failures may not include a populated `message`, which produces unclear Obsidian notices.

## Tests
- `corepack pnpm install --frozen-lockfile`
- `corepack pnpm run test:auth`
- `corepack pnpm run build`