### PR TITLE
fix(setting): harden copy debug info button handler on Android

### DIFF
--- a/src/setting.tsx
+++ b/src/setting.tsx
@@ -591,10 +591,12 @@ export class SettingTab extends PluginSettingTab {
     debugButton.onclick = async () => {
         try {
             await navigator.clipboard.writeText(this.getDebugInfo())
+            showSyncNotice($("setting.support.debug_desc"))
         } catch (e) {
             console.error("[fast-note-sync] copy debug info failed:", e)
+            // TODO(i18n): replace with localized key, e.g. $("setting.support.debug_copy_failed")
+            showSyncNotice("Failed to copy debug info.")
         }
-        showSyncNotice($("setting.support.debug_desc"))
     }
 
     if (isHomePage) {
@@ -603,8 +605,11 @@ export class SettingTab extends PluginSettingTab {
       issueButton.onclick = async () => {
         try {
             await navigator.clipboard.writeText(this.getDebugInfo())
+            showSyncNotice($("setting.support.debug_desc"))
         } catch (e) {
             console.error("[fast-note-sync] copy debug info failed:", e)
+            // TODO(i18n): replace with localized key, e.g. $("setting.support.debug_copy_failed")
+            showSyncNotice("Failed to copy debug info.")
         }
         new ConfirmModal(
           this.app,

--- a/src/setting.tsx
+++ b/src/setting.tsx
@@ -552,8 +552,8 @@ export class SettingTab extends PluginSettingTab {
           isDesktop: Platform.isDesktopApp,
           isMobile: Platform.isMobile,
           isTablet: Platform.isTablet,
-          platform: typeof process !== "undefined" ? process.platform : "unknown",
-          arch: typeof process !== "undefined" ? process.arch : "unknown",
+          platform: typeof process !== "undefined" ? (process.platform ?? "unknown"): "unknown",
+          arch: typeof process !== "undefined" ? (process.arch ?? "unknown") : "unknown",
           userAgent: "Obsidian/" + ((this.app as unknown as { version: string }).version || "unknown"),
           versions:
               typeof process !== "undefined" && process.versions

--- a/src/setting.tsx
+++ b/src/setting.tsx
@@ -556,14 +556,14 @@ export class SettingTab extends PluginSettingTab {
           arch: typeof process !== "undefined" ? process.arch : "unknown",
           userAgent: "Obsidian/" + ((this.app as unknown as { version: string }).version || "unknown"),
           versions:
-            typeof process !== "undefined"
-              ? {
+              typeof process !== "undefined" && process.versions
+                ? {
                 node: process.versions.node,
                 electron: process.versions.electron,
                 chrome: process.versions.chrome,
                 v8: process.versions.v8,
-              }
-              : {},
+                }
+                : {},
           capacitor: (window as unknown as { Capacitor: { getPlatform(): string; isNative: boolean } }).Capacitor
             ? {
               platform: (window as unknown as { Capacitor: { getPlatform(): string; isNative: boolean } }).Capacitor.getPlatform(),
@@ -589,15 +589,23 @@ export class SettingTab extends PluginSettingTab {
     const debugButton = debugDiv.createEl("button")
     debugButton.setText($("setting.support.debug_copy"))
     debugButton.onclick = async () => {
-      await navigator.clipboard.writeText(this.getDebugInfo())
-      showSyncNotice($("setting.support.debug_desc"))
+        try {
+            await navigator.clipboard.writeText(this.getDebugInfo())
+        } catch (e) {
+            console.error("[fast-note-sync] copy debug info failed:", e)
+        }
+        showSyncNotice($("setting.support.debug_desc"))
     }
 
     if (isHomePage) {
       const issueButton = debugDiv.createEl("button")
       issueButton.setText($("setting.support.issue"))
       issueButton.onclick = async () => {
-        await navigator.clipboard.writeText(this.getDebugInfo())
+        try {
+            await navigator.clipboard.writeText(this.getDebugInfo())
+        } catch (e) {
+            console.error("[fast-note-sync] copy debug info failed:", e)
+        }
         new ConfirmModal(
           this.app,
           $("ui.title.notice"),


### PR DESCRIPTION
## Summary / 概述

On Android, the **Copy Debug Info** and **Report Issue** buttons in
*Settings → Support* did nothing when tapped. This PR fixes both with a
minimal patch to `src/setting.tsx`.

在 Android 上，*设置 → 支持* 中的 **复制 Debug 信息** 与 **反馈问题** 按钮点击无反应。
本 PR 通过对 `src/setting.tsx` 的最小改动修复这两个按钮。

## Root Cause / 根因

1. **`getDebugInfo()` throws on Android.**
   Android Obsidian uses an esbuild `process` polyfill where
   `process.versions` is `undefined`, so `process.versions.node` throws
   `TypeError: Cannot read properties of undefined (reading 'node')`.
   The error fires **before** `clipboard.writeText`, so the click handler
   bails silently and neither the Notice nor the ConfirmModal ever shows.

   `getDebugInfo()` 在 Android 上抛错。Android Obsidian 的 `process` 是 esbuild
   polyfill，`process.versions` 为 `undefined`，访问 `process.versions.node`
   抛 `TypeError`。该错误发生在 `clipboard.writeText` 之前，导致 onclick 中断，
   Notice 和 ConfirmModal 都不出现，按钮看起来"没反应"。

2. **`process.arch` / `process.platform` are also missing on Android.**
   They evaluate to `undefined`, and `JSON.stringify` silently drops keys
   whose values are `undefined`, so the `arch` line was disappearing from
   the copied debug info instead of erroring out.

   `process.arch` / `process.platform` 在 Android 上同样为 `undefined`。
   `JSON.stringify` 会丢弃值为 `undefined` 的键，因此 debug 信息中的 `arch`
   行被静默丢掉（不是报错）。

3. **No error handling around `clipboard.writeText`.**
   If the clipboard call rejects on Android, the unhandled rejection
   prevents the following `showSyncNotice(...)` / `ConfirmModal.open()`
   from running.

   `clipboard.writeText` 没有 try/catch，一旦在 Android WebView 上 reject，
   后续的 `showSyncNotice` / `ConfirmModal.open()` 都不会执行。

## Changes / 改动

All changes are confined to `src/setting.tsx`:

所有改动都集中在 `src/setting.tsx`：

- **`getDebugInfo()`**

  - Add `&& process.versions` guard before reading
    `process.versions.{node,electron,chrome,v8}`.
  - Add `?? "unknown"` fallbacks for `process.platform` and `process.arch`.

  在读取 `process.versions.{node,electron,chrome,v8}` 前加 `&& process.versions` 守卫；
  为 `process.platform` 和 `process.arch` 增加 `?? "unknown"` 兜底。

- **`debugButton.onclick`** — `navigator.clipboard.writeText` is wrapped
  in try/catch. The success notice
  `$("setting.support.debug_desc")` is moved **into the try block** so
  it only fires after the copy actually succeeded. On failure a
  placeholder English notice is shown.

  `navigator.clipboard.writeText` 用 try/catch 包裹；成功提示
  `$("setting.support.debug_desc")` 移入 try 块，仅在复制成功后才显示；失败时
  显示一条英文占位提示。

- **`issueButton.onclick`** — same try/catch. The
  `ConfirmModal` is always opened so the button is never silent. 
  show a success notice when copying succeeds, and a failure notice when copying fails.

  同样用 try/catch 包裹；`ConfirmModal` 始终打开，避免按钮"没反应"；复制成功时显示成功提示，复制
  失败时显示失败提示。

## Follow-up needed from maintainer / 需要作者后续补充

I do not have access to the i18n translation tooling
(`scripts/translate-i18n.mjs` requires an OpenAI key), so the failure
notice in the `catch` branches is currently a hard-coded English string
with a `TODO(i18n)` comment:

我没有 i18n 翻译工具的 OpenAI key（`scripts/translate-i18n.mjs` 需要），所以
catch 分支里的失败提示目前是硬编码英文，并标注了 `TODO(i18n)` 注释：

```ts
// TODO(i18n): replace with localized key, e.g. $("setting.support.debug_copy_failed")
showSyncNotice("Failed to copy debug info.")
```

Suggested follow-up — please add a key such as `setting.support.debug_copy_failed` to `src/i18n/locales/zh-CN.ts` and `src/i18n/locales/en.ts`, then run `scripts/translate-i18n.mjs` to generate `ja` / `ko` / `zh-TW`, and replace the placeholder string with `$("setting.support.debug_copy_failed")`.

建议后续：在 `src/i18n/locales/zh-CN.ts` 和 `src/i18n/locales/en.ts` 中添加 `setting.support.debug_copy_failed` 之类的 key，然后运行 `scripts/translate-i18n.mjs` 自动生成 `ja` / `ko` / `zh-TW`，最后把占位字符串 替换为 `$("setting.support.debug_copy_failed")`。

## Testing / 测试

- Android (Obsidian Mobile): both buttons now respond. Debug info is copied with a complete `systemInfo` block (`arch: "unknown"` instead of disappearing). A prompt appears if copying fails. The *Report Issue* dialog opens as expected regardless of whether copying succeeded or failed.

  Android (Obsidian Mobile)：两个按钮都有响应；Debug 信息完整复制，`systemInfo` 中 `arch` 显示为 `"unknown"` 而不是消失；如果复制失败，也会有提示；不论复制成功还是失败，反馈问题弹窗都会正常打开。

- Desktop (Electron): unchanged behavior, full `versions` payload preserved.

  桌面端 (Electron)：行为不变，`versions` 字段完整。

## Notes / 备注

- The only outstanding item is the i18n key noted above; it does not block the fix from being effective.

  唯一遗留项是上述 i18n key，不影响本次修复生效。