### PR TITLE
fix: 修复冷启动阻塞 + 优化重连退避策略

### DIFF
--- a/src/lib/websocket.ts
+++ b/src/lib/websocket.ts
@@ -188,12 +188,7 @@ export class WebSocketClient {
     this.isRegister = true
 
     // 每次 ws 连接 / 重连 前 必须 先 /api/health 请求成功之后再请求ws
-    let isHealthy = await this.plugin.api.probeApiRedirect(this.plugin.runApi);
-    if (!isHealthy) {
-        // Capacitor 原生 HTTP 从后台恢复时可能未就绪，立即重试一次
-        // Capacitor native HTTP may not be ready after background; retry once immediately
-        isHealthy = await this.plugin.api.probeApiRedirect(this.plugin.runApi);
-    }
+    const isHealthy = await this.plugin.api.probeApiRedirect(this.plugin.runApi);
     if (!isHealthy) {
         dump("Health check failed before ws connect, scheduling reconnect...");
         if (this.plugin.settings.autoRedirectEnabled) {
@@ -464,8 +459,11 @@ export class WebSocketClient {
     }
     if (!this.ws || this.ws.readyState === WebSocket.CLOSED) {
       this.timeConnect++
-      // Exponential backoff: 3s, 6s, 12s, 24s...
-      let delay = RECONNECT_BASE_DELAY * Math.pow(2, this.timeConnect - 1)
+      // 前 3 次固定 1s，之后指数增长: 1s, 1s, 1s, 2s, 4s, 8s...
+      // First 3 attempts fixed 1s to handle Capacitor HTTP warm-up, then exponential
+      let delay = this.timeConnect <= 3
+        ? RECONNECT_BASE_DELAY
+        : RECONNECT_BASE_DELAY * Math.pow(2, this.timeConnect - 3)
 
       // 调试地址回退逻辑
       const debugUrls = this.plugin.settings.debugRemoteUrls ? this.plugin.settings.debugRemoteUrls.split("\n").filter(u => u.trim() !== "") : []

--- a/src/main.ts
+++ b/src/main.ts
@@ -62,7 +62,7 @@ export default class FastSync extends Plugin {
   clipboardReadTip: string = "" // 剪贴板读取提示信息
 
   isFirstSync: boolean = false // 是否为首次同步
-  isWatchEnabled: boolean = false // 是否启用文件监听
+  isWatchEnabled: boolean = true // 是否启用文件监听
   ignoredFiles: Set<string> = new Set() // 忽略的文件集合
   ignoredConfigFiles: Set<string> = new Set() // 忽略的配置文件集合
   lastSyncMtime: Map<string, number> = new Map() // 最后同步的修改时间


### PR DESCRIPTION
# 本次PR包括1个修复，2个优化，1个新特性
Commit 384a6b63f9f9df66375979a29172a991eb35f862 包括1个修复和2个优化
Commit b87ff55682301c918528601909fca6a769f8d0cd 包括1个新特性

## 1 一个修复
### 问题 1：冷启动 health check 失败后被误拦

`isWatchEnabled` 初始值为 `false`，只有 `StartHandle` 成功后才置 `true`。冷启动时若第一次 health check 失败，`checkReConnect` 的 `isWatchEnabled` 守卫会直接 return，导致永远无法重连。

## 2个优化：
### 优化1：health check 失败后立即重试加倍耗时

Capacitor 原生 HTTP 从后台恢复时每次调用都超时 1s，两次背靠背调用 = 2s 不必要的超时，优化为走 checkReConnect 的自然退避。

### 优化2：纯指数退避不适应移动端网络栈恢复场景

- 原退避策略为纯指数增长（1s→2s→4s→8s→16s...）。但移动端 Capacitor 原生 HTTP 从后台恢复时需要 2-3 次调用"预热"，等待更久并不会提高成功率。改为"线性预热 + 指数退避"（linear then exponential）：前 3 次固定 1s 间隔快速预热，之后指数增长应对服务端不可用。
- 调用调试地址，应该等待预热完成后（也就是前三次重试之后），再进行调试地址调用

## 1个新特性：
#### 同步进行时，在ribbon按钮上有直观的状态显示
<img width="426" height="218" alt="iShot_2026-05-19_14 11 30" src="https://github.com/user-attachments/assets/18c05e4c-154d-47e8-896f-b8bf8522a420" />