### PR TITLE
fix: 修复冷启动阻塞 + 优化重连退避策略 + 新特性: 同步状态动态指示

### DIFF
--- a/src/lib/concurrency_manager.ts
+++ b/src/lib/concurrency_manager.ts
@@ -120,4 +120,9 @@ export class ConcurrencyManager {
         // 拒绝所有正在等待的 Promise（可选，这里简单清空队列）
         this.queue = [];
     }
+
+    /** 是否有待确认的操作（等待服务端 ACK）/ Whether there are pending operations awaiting ACK */
+    public hasPending(): boolean {
+        return this.activeKeys.size > 0 || this.queue.length > 0;
+    }
 }

--- a/src/lib/menu_manager.ts
+++ b/src/lib/menu_manager.ts
@@ -406,6 +406,25 @@ export class MenuManager {
     });
   }
 
+  /**
+   * 设置同步状态 → 切换颜色动画
+   * Set sync status → toggle color animation
+   */
+  setSyncStatus(syncing: boolean) {
+    // 同步处理 ribbon 图标和 view-actions 按钮 / Handle both ribbon icon and view-actions buttons
+    [this.ribbonIcon, ...Array.from(activeDocument.querySelectorAll('.fns-status-action'))].forEach(el => {
+      if (!el) return;
+      if (syncing) {
+        if (!el.querySelector('.fns-sync-spinner')) {
+          const spinner = el.createDiv('fns-sync-spinner');
+          setIcon(spinner, 'refresh-cw');
+        }
+      } else {
+        el.querySelector('.fns-sync-spinner')?.remove();
+      }
+    });
+  }
+
   updateStatusBar(text: string, current?: number, total?: number) {
     if (!this.statusBarText) {
       this.statusBarItem.addClass("fast-note-sync-status-bar-progress");

--- a/src/lib/websocket.ts
+++ b/src/lib/websocket.ts
@@ -151,6 +151,17 @@ export class WebSocketClient {
     this.statusListeners.forEach(listener => listener(status));
   }
 
+  /** 数据传输活动监听器 / Data transfer activity listeners */
+  private activityListeners: Set<() => void> = new Set();
+
+  public addActivityListener(listener: () => void) {
+    this.activityListeners.add(listener);
+  }
+
+  private notifyActivity() {
+    this.activityListeners.forEach(fn => fn());
+  }
+
   public isConnected(): boolean {
     return this.isOpen
   }
@@ -298,6 +309,7 @@ export class WebSocketClient {
               // Pass the rest of the data
               const rest = buf.slice(2);
               handler(rest, this.plugin);
+              this.notifyActivity();
             } else {
               dump("No handler for binary prefix:", prefixStr);
             }
@@ -400,6 +412,7 @@ export class WebSocketClient {
           const handler = receiveOperators.get(msgAction)
           if (handler) {
             void handler(data.data, this.plugin)
+            this.notifyActivity()
           }
         }
       }
@@ -607,6 +620,7 @@ export class WebSocketClient {
     this.Send(action, data, () => {
       SyncLogManager.getInstance().logSentMessage(action, data, this.plugin.currentSyncType);
       after?.()
+      this.notifyActivity()
     })
 
   }
@@ -662,6 +676,7 @@ export class WebSocketClient {
 
     this.ws.send(dataToSend)
     after?.()
+    this.notifyActivity()
     return false; // 返回 false 表示正常发送
   }
 

--- a/src/lib/websocket.ts
+++ b/src/lib/websocket.ts
@@ -188,12 +188,7 @@ export class WebSocketClient {
     this.isRegister = true
 
     // 每次 ws 连接 / 重连 前 必须 先 /api/health 请求成功之后再请求ws
-    let isHealthy = await this.plugin.api.probeApiRedirect(this.plugin.runApi);
-    if (!isHealthy) {
-        // Capacitor 原生 HTTP 从后台恢复时可能未就绪，立即重试一次
-        // Capacitor native HTTP may not be ready after background; retry once immediately
-        isHealthy = await this.plugin.api.probeApiRedirect(this.plugin.runApi);
-    }
+    const isHealthy = await this.plugin.api.probeApiRedirect(this.plugin.runApi);
     if (!isHealthy) {
         dump("Health check failed before ws connect, scheduling reconnect...");
         if (this.plugin.settings.autoRedirectEnabled) {
@@ -459,33 +454,30 @@ export class WebSocketClient {
     }
     window.clearTimeout(this.checkReConnectTimeout)
     if (this.timeConnect > 15) {
-      // Max attempts hardcoded or use constant
       return
     }
     if (!this.ws || this.ws.readyState === WebSocket.CLOSED) {
       this.timeConnect++
-      // Exponential backoff: 3s, 6s, 12s, 24s...
-      let delay = RECONNECT_BASE_DELAY * Math.pow(2, this.timeConnect - 1)
+      // 前 3 次固定 1s，之后指数增长，最大 30min: 1s, 1s, 1s, 2s, 4s, 8s, 16s, 32s, 64s, 128s, 256s, 512s, 1024s, 1800s, 1800s...
+      let delay = this.timeConnect <= 3
+        ? RECONNECT_BASE_DELAY
+        : Math.min(RECONNECT_BASE_DELAY * Math.pow(2, this.timeConnect - 3), 1800000)
 
-      // 调试地址回退逻辑
+      // 调试地址回退逻辑（预热 3 次后再尝试）
       const debugUrls = this.plugin.settings.debugRemoteUrls ? this.plugin.settings.debugRemoteUrls.split("\n").filter(u => u.trim() !== "") : []
       if (debugUrls.length > 0) {
-        // 从第2次重试开始尝试调试地址
-        if (this.timeConnect >= 2 && this.timeConnect < 2 + debugUrls.length) {
-          const index = this.timeConnect - 2
+        if (this.timeConnect >= 4 && this.timeConnect < 4 + debugUrls.length) {
+          const index = this.timeConnect - 4
           const url = debugUrls[index].trim()
           if (url) {
             dump(`Trying debug URL [${index + 1}/${debugUrls.length}]: ${url}`)
-            // 更新运行时 API
             this.plugin.runApi = url.replace(/\/+$/, "")
             this.plugin.runWsApi = url.replace(/^http/, "ws").replace(/\/+$/, "")
 
-            // 调试尝试使用较短延迟
             delay = 1000
             showSyncNotice(`[FastSync] 尝试连接调试地址: ${url}`)
           }
-        } else if (this.timeConnect === 2 + debugUrls.length) {
-          // 调试地址全部失败后，恢复配置的原始地址
+        } else if (this.timeConnect === 4 + debugUrls.length) {
           this.plugin.updateRuntimeApi(this.plugin.settings.api);
           dump(`Debug URLs failed, reverting to settings API`)
         }

--- a/src/main.ts
+++ b/src/main.ts
@@ -62,7 +62,7 @@ export default class FastSync extends Plugin {
   clipboardReadTip: string = "" // 剪贴板读取提示信息
 
   isFirstSync: boolean = false // 是否为首次同步
-  isWatchEnabled: boolean = false // 是否启用文件监听
+  isWatchEnabled: boolean = true // 是否启用文件监听
   ignoredFiles: Set<string> = new Set() // 忽略的文件集合
   ignoredConfigFiles: Set<string> = new Set() // 忽略的配置文件集合
   lastSyncMtime: Map<string, number> = new Map() // 最后同步的修改时间

--- a/src/main.ts
+++ b/src/main.ts
@@ -389,6 +389,23 @@ export default class FastSync extends Plugin {
       // 注册 WebSocket 状态监听 (Register WebSocket status listener)
       this.websocket.addStatusListener((status: boolean) => this.updateRibbonIcon(status))
 
+      // 注册 WebSocket 数据传输活动监听 — 任何数据收发时显示同步指示器 / Register data transfer activity listener
+      let activityTimer: ReturnType<typeof setTimeout> | null = null;
+      const scheduleTurnOff = () => {
+        if (activityTimer) clearTimeout(activityTimer);
+        activityTimer = setTimeout(() => {
+          if (this.concurrencyManager.hasPending()) {
+            scheduleTurnOff(); // 还有未确认操作，200ms 后再检查 / Still pending ACKs, recheck
+          } else {
+            this.menuManager.setSyncStatus(false);
+          }
+        }, 600);
+      };
+      this.websocket.addActivityListener(() => {
+        this.menuManager.setSyncStatus(true);
+        scheduleTurnOff();
+      });
+
       // 初始化分享指示器管理器 / Initialize share indicator manager
       this.shareIndicatorManager = new ShareIndicatorManager(this)
       void this.shareIndicatorManager.initialize()

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -60,6 +60,25 @@
   }
 }
 
+/* 同步中：wifi 图标上叠加旋转 refresh-cw 图标 / Syncing: spinning refresh-cw icon overlay */
+.fns-sync-spinner {
+  position: absolute;
+  top: calc(50% + 3px);
+  left: calc(50% + 6px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  pointer-events: none;
+
+  svg {
+    width: 8px;
+    height: 8px;
+    stroke-width: 3;
+    animation: rotate 1.2s linear infinite;
+    color: inherit;
+  }
+}
+
 .fns-modal-warning-message {
   color: var(--text-error);
   margin-bottom: 20px;

--- a/styles.css
+++ b/styles.css
@@ -51,6 +51,24 @@
     transform: rotate(-360deg);
   }
 }
+/* 同步中：wifi 图标上叠加旋转 refresh-cw 图标 / Syncing: spinning refresh-cw icon overlay */
+.fns-sync-spinner {
+  position: absolute;
+  top: calc(50% + 3px);
+  left: calc(50% + 6px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  pointer-events: none;
+}
+.fns-sync-spinner svg {
+  width: 8px;
+  height: 8px;
+  stroke-width: 3;
+  animation: rotate 1.2s linear infinite;
+  color: inherit;
+}
+
 .fns-modal-warning-message {
   color: var(--text-error);
   margin-bottom: 20px;


### PR DESCRIPTION
## 本次PR包括1个修复，2个优化，1个新特性

Commit 384a6b6 包括1个修复和2个优化
Commit b87ff55 包括1个新特性

## 1 一个修复
### 问题：冷启动 health check 失败后被误拦

`isWatchEnabled` 初始值为 `false`，只有 `StartHandle` 成功后才置 `true`。冷启动时若第一次 health check 失败，`checkReConnect` 的 `isWatchEnabled` 守卫会直接 return，导致永远无法重连。

## 2个优化
### 优化1：health check 失败后不应该立即重试，否则加倍耗时

Capacitor 原生 HTTP 从后台恢复时每次调用都超时 1s，两次背靠背调用 = 2s 不必要的超时，优化为走 checkReConnect 的自然退避。

### 优化2：纯指数退避不适应移动端网络栈恢复场景

- 原退避策略为纯指数增长（1s→2s→4s→8s→16s...）。但移动端 Capacitor 原生 HTTP 从后台恢复时需要 2-3 次调用"预热"，等待更久并不会提高成功率。改为"线性预热 + 指数退避"（linear then exponential）：前 3 次固定 1s 间隔快速预热，之后指数增长应对服务端不可用。
- 调用调试地址，应该等待预热完成后（也就是前三次重试之后），再进行调试地址调用

## 1个新特性
### 同步进行时，在ribbon按钮上有直观的’Syncing‘的状态显示

<img width="426" height="218" alt="iShot_2026-05-19_14 11 30" src="https://github.com/user-attachments/assets/18c05e4c-154d-47e8-896f-b8bf8522a420" />