### PR TITLE
fix:修复手动模式下同步状态显示器一直显示的问题+feat:新增同步状态显示器开关

### DIFF
--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -103,6 +103,8 @@ export default {
   "setting.general.show_share_icon_desc": "When enabled, icons for shared notes will be displayed in the <b>native file manager</b> and the third-party plugin <b>Notebook Navigator</b>.",
   "setting.general.show_upgrade_badge": "Show update badge on main interface",
   "setting.general.show_upgrade_badge_desc": "When enabled, displays a red dot notification on the sidebar, mobile top bar, and sync log icon when the plugin or server has a new version.",
+  "setting.display.show_sync_indicator": "Show sync status indicator",
+  "setting.display.show_sync_indicator_desc": "When enabled, a spinning icon appears on the bottom-right of the icon button during data transfer.",
   "setting.sync.config_dirs": "Config Sync - Add Directory Sync",
   "setting.sync.config_dirs_desc": "In addition to core config sync, add special directories that need to be synced (must start with <b>.</b>).\nNote: Paths not starting with <b>.</b> will be automatically ignored; all files under these directories will participate in sync, e.g., .claude.",
   "setting.sync.config_dirs_placeholder": "Enter directory paths to add for sync, must start with ., e.g., .claude",

--- a/src/i18n/locales/ja.ts
+++ b/src/i18n/locales/ja.ts
@@ -103,6 +103,8 @@ export default {
   "setting.general.show_share_icon_desc": "有効にすると、<b>ネイティブファイルマネージャー</b> および <b>Notebook Navigator</b> サードパーティプラグインで、共有済みのノートのアイコンが表示されます。",
   "setting.general.show_upgrade_badge": "メイン画面に更新の赤い点を表示",
   "setting.general.show_upgrade_badge_desc": "有効にすると、プラグインまたはサーバーに新しいバージョンがある場合、サイドバー、モバイル端末の上部バー、および同期ログアイコンに赤い点の通知を表示します。",
+  "setting.display.show_sync_indicator": "同期状態インジケーターを表示",
+  "setting.display.show_sync_indicator_desc": "有効にすると、データ転送中にアイコンボタンの右下に回転アイコンが表示されます。",
   "setting.sync.config_dirs": "設定同期 - 追加ディレクトリの同期",
   "setting.sync.config_dirs_desc": "コア設定の同期に加えて、同期が必要な特殊ディレクトリを追加します（<b>.</b> で始まる必要があります）。\n注意：<b>.</b> で始まらないパスは自動的に無視され、これらのディレクトリ内のすべてのファイルが同期に参加します。例：.claude。",
   "setting.sync.config_dirs_placeholder": "追加で同期するディレクトリパスを入力してください。<b>.</b> で始まる必要があります。例：.claude",

--- a/src/i18n/locales/ko.ts
+++ b/src/i18n/locales/ko.ts
@@ -103,6 +103,8 @@ export default {
   "setting.general.show_share_icon_desc": "활성화하면 <b>네이티브 파일 관리자</b> 및 <b>Notebook Navigator</b> 서드파티 플러그인에서 공유된 노트의 아이콘을 표시합니다.",
   "setting.general.show_upgrade_badge": "메인 화면에 업데이트 배지 표시",
   "setting.general.show_upgrade_badge_desc": "활성화하면 플러그인이나 서버에 새 버전이 있을 때 사이드바, 모바일 상단 바 및 동기화 로그 아이콘에 빨간 점 알림이 표시됩니다.",
+  "setting.display.show_sync_indicator": "동기화 상태 표시기 표시",
+  "setting.display.show_sync_indicator_desc": "활성화하면 데이터 전송 중에 아이콘 버튼 오른쪽 하단에 회전 아이콘이 표시됩니다.",
   "setting.sync.config_dirs": "설정 동기화-추가 디렉토리 동기화",
   "setting.sync.config_dirs_desc": "핵심 설정 동기화基礎上, 동기화할 특수 디렉토리를 추가합니다 (<b>.</b>로 시작해야 합니다).\n주의: <b>.</b>로 시작하지 않는 경로는 자동으로 무시되며, 이러한 디렉토리의 모든 파일이 동기화에 참여합니다. 예: .claude.",
   "setting.sync.config_dirs_placeholder": "추가 동기화할 디렉토리 경로를 입력하세요. . 로 시작해야 합니다. 예: .claude",

--- a/src/i18n/locales/zh-CN.ts
+++ b/src/i18n/locales/zh-CN.ts
@@ -103,6 +103,8 @@ export default {
   "setting.general.show_share_icon_desc": "开启后，在 <b>原生文件管理器</b> 和 <b>Notebook Navigator</b> 三方插件中显示已分享笔记的图标。",
   "setting.general.show_upgrade_badge": "主界面显示更新红点",
   "setting.general.show_upgrade_badge_desc": "开启后，当插件或服务端有新版本时，在侧边栏、移动端顶栏及同步日志图标上显示红点提示。",
+  "setting.display.show_sync_indicator": "显示同步状态指示器",
+  "setting.display.show_sync_indicator_desc": "开启后，数据传输时会在图标按钮右下角显示旋转图标。",
   "setting.sync.config_dirs": "配置同步-增加目录同步",
   "setting.sync.config_dirs_desc": "在核心配置同步基础上，增加需要同步的特殊目录（必须以 <b>.</b> 开头）。\n注意：不以 <b>.</b> 开头的路径将被自动忽略，这些目录下的所有文件都将参与同步，例如：.claude。",
   "setting.sync.config_dirs_placeholder": "输入需要增加同步的目录路径，必须以 . 开头，如：.claude",

--- a/src/i18n/locales/zh-TW.ts
+++ b/src/i18n/locales/zh-TW.ts
@@ -103,6 +103,8 @@ export default {
   "setting.general.show_share_icon_desc": "開啟後，在 <b>原生檔案管理器</b> 和 <b>Notebook Navigator</b> 三方外掛中顯示已分享筆記的圖示。",
   "setting.general.show_upgrade_badge": "主介面顯示更新紅點",
   "setting.general.show_upgrade_badge_desc": "開啟後，當外掛或伺服器端有新版本時，在側邊欄、行動裝置頂部欄位及同步日誌圖示上顯示紅點提示。",
+  "setting.display.show_sync_indicator": "顯示同步狀態指示器",
+  "setting.display.show_sync_indicator_desc": "開啟後，數據傳輸時會在本圖示按鈕右下角顯示旋轉圖示。",
   "setting.sync.config_dirs": "配置同步-增加目錄同步",
   "setting.sync.config_dirs_desc": "在核心配置同步基礎上，增加需要同步的特殊目錄（必須以 <b>.</b> 開頭）。\n注意：不以 <b>.</b> 開頭的路徑將被自動忽略，這些目錄下的所有檔案都將參與同步，例如：.claude。",
   "setting.sync.config_dirs_placeholder": "輸入需要增加同步的目錄路徑，必須以 . 開頭，如：.claude",

--- a/src/lib/menu_manager.ts
+++ b/src/lib/menu_manager.ts
@@ -414,6 +414,7 @@ export class MenuManager {
    * Set sync status → toggle color animation
    */
   setSyncStatus(syncing: boolean) {
+    if (!this.plugin.settings.showSyncIndicator) return;
     // 同步处理 ribbon 图标和 view-actions 按钮 / Handle both ribbon icon and view-actions buttons
     [this.ribbonIcon, ...Array.from(activeDocument.querySelectorAll('.fns-status-action'))].forEach(el => {
       if (!el) return;

--- a/src/lib/websocket.ts
+++ b/src/lib/websocket.ts
@@ -427,6 +427,9 @@ export class WebSocketClient {
   private cleanupWebSocket(ws: WebSocket) {
     if (!ws) return;
 
+    // 清理残留并发槽位 / Clear stale concurrency slots
+    this.plugin.concurrencyManager.clear();
+
     // Remove listeners to prevent "ghost" events
     ws.onopen = null;
     ws.onmessage = null;

--- a/src/setting.tsx
+++ b/src/setting.tsx
@@ -146,7 +146,7 @@ export const DEFAULT_SETTINGS: PluginSettings = {
   concurrencyControlEnabled: false,
   maxConcurrentUploads: 20,
   showConcurrencyIndicator: true,
-  showSyncIndicator: true,
+  showSyncIndicator: false,
   autoRedirectEnabled: false,
   wsPreProbeEnabled: true,
   // 手机 110，平板 126，与 CSS 硬编码值一致 / Phone 110, tablet 126, matches CSS defaults

--- a/src/setting.tsx
+++ b/src/setting.tsx
@@ -1,4 +1,4 @@
-import { App, PluginSettingTab, Setting, Platform, SearchComponent, MarkdownRenderer, Component, requestUrl, Modal } from "obsidian";
+import { App, PluginSettingTab, Setting, Platform, SearchComponent, MarkdownRenderer, Component, requestUrl, Modal, setIcon } from "obsidian";
 import { createRoot, Root } from "react-dom/client";
 import { unzipSync } from "fflate";
 
@@ -86,6 +86,8 @@ export interface PluginSettings {
   maxConcurrentUploads: number
   /** 是否在状态栏显示并发控制图标 */
   showConcurrencyIndicator: boolean
+  /** 是否显示同步状态指示器（旋转图标）/ Whether to show sync status indicator (spinning icon) */
+  showSyncIndicator: boolean
   /** 是否自动检测 API 跳转 (301/302) */
   autoRedirectEnabled: boolean
   /** 是否在WS连接前进行探测 */
@@ -144,6 +146,7 @@ export const DEFAULT_SETTINGS: PluginSettings = {
   concurrencyControlEnabled: false,
   maxConcurrentUploads: 20,
   showConcurrencyIndicator: true,
+  showSyncIndicator: true,
   autoRedirectEnabled: false,
   wsPreProbeEnabled: true,
   // 手机 110，平板 126，与 CSS 硬编码值一致 / Phone 110, tablet 126, matches CSS defaults
@@ -1065,6 +1068,23 @@ export class SettingTab extends PluginSettingTab {
       }),
     )
     this.setDescWithBreaks(set.lastElementChild as HTMLElement, $("setting.general.show_upgrade_badge_desc"))
+
+    // 同步状态指示器 / Sync status indicator
+    const syncSetting = new Setting(set).setName($("setting.display.show_sync_indicator")).setClass("fns-setting-item-checkbox").addToggle((toggle) =>
+      toggle.setValue(this.plugin.settings.showSyncIndicator).onChange(async (value) => {
+        this.plugin.settings.showSyncIndicator = value
+        await this.plugin.saveSettings()
+      }),
+    )
+    // 在标签右侧嵌入合成图标的静态预览 / Embed static composite icon preview next to label
+    const preview = syncSetting.nameEl.createDiv("fns-sync-indicator-preview")
+    const previewContainer = preview.createDiv("fns-ribbon-container")
+    setIcon(previewContainer, "wifi")
+    const previewSpinner = previewContainer.createDiv("fns-sync-spinner")
+    previewSpinner.classList.add("fns-sync-preview")
+    setIcon(previewSpinner, "refresh-cw")
+    const syncDescEl = set.lastElementChild as HTMLElement
+    this.setDescWithBreaks(syncDescEl, $("setting.display.show_sync_indicator_desc"))
 
     new Setting(set).setName($("setting.sync.show_concurrency_indicator")).setClass("fns-setting-item-checkbox").addToggle((toggle) =>
       toggle.setValue(this.plugin.settings.showConcurrencyIndicator).onChange(async (value) => {

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -79,6 +79,39 @@
   }
 }
 
+/* 设置页同步指示器预览 / Settings page sync indicator preview */
+.fns-sync-indicator-preview {
+  display: inline-flex;
+  align-items: center;
+  margin-left: 6px;
+  vertical-align: middle;
+  height: 1.1em;
+
+  .fns-ribbon-container {
+    width: 14px;
+    height: 14px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+
+    svg {
+      width: 14px;
+      height: 14px;
+    }
+  }
+
+  .fns-sync-spinner {
+    top: calc(50% + 2px);
+    left: calc(50% + 4px);
+
+    svg {
+      animation: none;
+      width: 5.6px;
+      height: 5.6px;
+    }
+  }
+}
+
 .fns-modal-warning-message {
   color: var(--text-error);
   margin-bottom: 20px;

--- a/styles.css
+++ b/styles.css
@@ -69,6 +69,35 @@
   color: inherit;
 }
 
+/* 设置页同步指示器预览 / Settings page sync indicator preview */
+.fns-sync-indicator-preview {
+  display: inline-flex;
+  align-items: center;
+  margin-left: 6px;
+  vertical-align: middle;
+  height: 1.1em;
+}
+.fns-sync-indicator-preview .fns-ribbon-container {
+  width: 14px;
+  height: 14px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.fns-sync-indicator-preview .fns-ribbon-container svg {
+  width: 14px;
+  height: 14px;
+}
+.fns-sync-indicator-preview .fns-sync-spinner {
+  top: calc(50% + 2px);
+  left: calc(50% + 4px);
+}
+.fns-sync-indicator-preview .fns-sync-spinner svg {
+  animation: none;
+  width: 5.6px;
+  height: 5.6px;
+}
+
 .fns-modal-warning-message {
   color: var(--text-error);
   margin-bottom: 20px;


### PR DESCRIPTION
# Fix 修复手动模式下同步状态显示器一直显示的问题
Commit [b50218a](https://github.com/chenxiccc/obsidian-fast-note-sync/commit/b50218ab1308892b5c8e412d04132b6e50063d27)
cleanupWebSocket 时清除残留并发槽位，防止同步指示器无法关闭

# Feat:新增同步状态显示器开关，默认关闭
Commit [8a99f24 ](https://github.com/chenxiccc/obsidian-fast-note-sync/commit/8a99f24e82abace6706473d5ae35ec7f5dfb3178)
<img width="500"  alt="image" src="https://github.com/user-attachments/assets/070fc7e2-1cc2-4969-9585-a95844896fd5" />
