### PR TITLE
fix(setting): add recursive sensitive-info sanitizer to debug output

### DIFF
--- a/src/setting.tsx
+++ b/src/setting.tsx
@@ -501,6 +501,8 @@ export class SettingTab extends PluginSettingTab {
   }
 
   private getDebugInfo(): string {
+    // 单个 URL 的脱敏：保留协议与端口，host 仅保留首尾字符
+    // Mask a single URL: keep protocol and port, replace host middle with ***
     const maskValue = (val: string) => {
       if (!val) return ""
       const parts = val.split("://")
@@ -525,14 +527,54 @@ export class SettingTab extends PluginSettingTab {
       return protocol + maskedHost + port
     }
 
-    return JSON.stringify(
-      {
-        settings: {
-          ...this.plugin.settings,
-          api: maskValue(this.plugin.settings.api),
-          apiToken: this.plugin.settings.apiToken ? "***HIDDEN***" : "",
-        },
-        runtimeInfo: {
+    // 多行 URL 字段逐行脱敏，保留非 URL 行原样
+    // Mask multi-line URL fields line-by-line, leaving non-URL lines untouched
+    const maskMultiline = (val: string) => {
+      if (!val.includes("\n")) return maskValue(val)
+      return val
+        .split("\n")
+        .map((line) => (line.includes("://") ? maskValue(line) : line))
+        .join("\n")
+    }
+
+    // 兜底敏感扫描：在显式脱敏之外，递归扫描整个 debug 对象
+    // - 键名命中 SECRET_KEY_RE 的字符串字段：整体替换为 ***HIDDEN***
+    // - 键名命中 URL_KEY_RE 且值含 "://" 的字符串字段：用 maskValue 脱敏
+    // 目的：当 PluginSettings 新增字段、或老版本残留字段出现时，即使忘记在显式列表里添加脱敏，也能自动覆盖。
+    // Defense-in-depth: recursive sanitize as a safety net beyond explicit masking.
+    const SECRET_KEY_RE = /token|secret|password|passphrase|credential|apikey/i
+    const URL_KEY_RE = /api|url|endpoint|gateway|host|origin/i
+    const sanitize = (node: unknown): unknown => {
+      if (Array.isArray(node)) return node.map(sanitize)
+      if (node && typeof node === "object") {
+        const out: Record<string, unknown> = {}
+        for (const [k, v] of Object.entries(node as Record<string, unknown>)) {
+          if (typeof v === "string" && v.length > 0) {
+            if (SECRET_KEY_RE.test(k)) {
+              out[k] = "***HIDDEN***"
+            } else if (URL_KEY_RE.test(k) && v.includes("://")) {
+              out[k] = maskMultiline(v)
+            } else {
+              out[k] = v
+            }
+          } else {
+            out[k] = sanitize(v)
+          }
+        }
+        return out
+      }
+      return node
+    }
+
+    // debug信息，显式脱敏作为主防线
+    // debugInfo, Explicit masking is the primary line
+    const debugInfo = {
+      settings: {
+        ...this.plugin.settings,
+        api: maskValue(this.plugin.settings.api),
+        apiToken: this.plugin.settings.apiToken ? "***HIDDEN***" : "",
+      },
+      runtimeInfo: {
           runApi: maskValue(this.plugin.runApi),
           runWsApi: maskValue(this.plugin.runWsApi),
           isInitSync: this.plugin.localStorageManager.getMetadata("isInitSync"),
@@ -578,10 +620,10 @@ export class SettingTab extends PluginSettingTab {
           obsidianVersion: (this.app as unknown as { version: string }).version || "unknown",
         },
         pluginVersion: this.plugin.manifest.version,
-      },
-      null,
-      4,
-    )
+    }
+    // sanitize 兜底敏感扫描作为次防线，避免遗漏任何敏感信息
+    // sanitize as a secondary line to catch any missed sensitive info
+    return JSON.stringify(sanitize(debugInfo), null, 4)
   }
 
   private renderDebugTools(set: HTMLElement, isHomePage: boolean = false) {


### PR DESCRIPTION
### 问题

Issue #172 中的第二个问题：在插件设置中点击“复制 Debug 信息”时，输出的 JSON 中的 `wsApi` 字段没有脱敏，原样泄漏，例如：

json

```
"wsApi": "wss://..."
```

而 `api`、`apiToken`、`runWsApi` 等字段均已正常脱敏。

### 原因

`setting.tsx` 的 `getDebugInfo()` 在构造 `settings` 段时使用：

```
settings: {
  ...this.plugin.settings,
  api: maskValue(this.plugin.settings.api),
  apiToken: this.plugin.settings.apiToken ? "***HIDDEN***" : "",
},
```

`wsApi` 在 `PluginSettings` 中的提交 [4de5878](https://github.com/haierkeys/obsidian-fast-note-sync/commit/4de5878dc1565d33056eb44c7f1a672d24d1db04) "新增 301 支持" (2026-03-03) 中被移除。对于在那之前升级的用户， `wsApi` （以及任何未来类似移除的字段）会保留在 `data.json` 中，并通过 `...this.plugin.settings` 在 `saveSettings` 中永久重新持久化。

`...this.plugin.settings` 将其原样展开且没有任何覆盖，导致泄漏。

此外，`debugRemoteUrls` 和 `cloudPreviewRemoteUrl` 在填充后同样未做任何脱敏处理。

### 改动

- **增加递归敏感信息清理器**（defense-in-depth）：
  - 在显式白名单脱敏之后，递归遍历整个 debug 对象。
  - 对键名匹配 `SECRET_KEY_RE`（`token|secret|password|...`）的字段，值替换为 `***HIDDEN***`。
  - 对键名匹配 `URL_KEY_RE`（`api|url|endpoint|...`）且值包含 `://` 的字段，调用 `maskValue` 进行脱敏（支持多行 URL 逐行处理）。
- **保留原有显式脱敏**作为主要防御手段，新清理器作为兜底。

`maskValue` 具有幂等性，多层脱敏不会产生双重遮蔽副作用。

### 测试

- 手动复制 Debug 信息，验证 `wsApi`、`debugRemoteUrls`、`cloudPreviewRemoteUrl`、`testToken`、`testUrl` 等字段已正确脱敏，**新增的测试字段（如 `testToken`、`testUrl` 等）也能被自动隐藏**，无需逐个手动添加白名单。
<img width="215" height="52" alt="测试图" src="https://github.com/user-attachments/assets/149a753a-0261-4a80-96e3-0654b0d35fa7" />

- 确认原有显式脱敏字段（`api`、`apiToken` 等）行为不变。

### 相关 Issue

#172 （第二个问题）