### PR TITLE
fix: 改善授权错误提示，针对 Code=315 给出 scope 权限检查指引

### DIFF
--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -223,6 +223,8 @@ export default {
   "ui.status.api_connected": "Connected to identified service address: ${url}",
   "ui.status.api_redirected": "Remote service address redirection detected, automatically updated to: ${url}",
   "ui.status.last_sync_not_completed": "The previous full sync has not yet completed. Please wait patiently or check the server status.",
+  "ui.status.auth_error": "Service Authorization Error: Code=${code} Message=${message}",
+  "ui.status.auth_error_scope": "Authorization failed (Code=315): Token scope insufficient. Please verify: 1) the token scope includes 'ws' protocol permission, 2) the token scope matches the client type (ObsidianPlugin), 3) the token was created with the appropriate permissions.",
 
   // --- ui.version ---
   "ui.version.title": "Version Information",

--- a/src/i18n/locales/zh-CN.ts
+++ b/src/i18n/locales/zh-CN.ts
@@ -223,6 +223,8 @@ export default {
   "ui.status.api_connected": "已连接到识别后的服务地址: ${url}",
   "ui.status.api_redirected": "检测到远端服务地址重定向，已自动更新为: ${url}",
   "ui.status.last_sync_not_completed": "上一次的全部同步尚未完成，请耐心等待或检查服务端状态",
+  "ui.status.auth_error": "服务授权错误: Code=${code} Message=${message}",
+  "ui.status.auth_error_scope": "授权失败 (Code=315)：Token scope 权限不足。请检查：1) Token scope 是否包含 'ws' 协议权限；2) Token scope 是否与客户端类型 (ObsidianPlugin) 匹配；3) Token 创建时是否授予了合适的权限。",
 
   // --- ui.version ---
   "ui.version.title": "版本信息",

--- a/src/lib/websocket.ts
+++ b/src/lib/websocket.ts
@@ -266,9 +266,14 @@ export class WebSocketClient {
 
         if (msgAction == "Authorization") {
           if (data.code <= 0 || data.code >= 300) {
-            const errorMsg = data.message || "";
-            const errorDetails = data.details ? " Details=" + data.details : "";
-            showSyncNotice("Service Authorization Error: Code=" + data.code + " Msg=" + errorMsg + errorDetails)
+            const rawMsg = data.message
+            const errorMsg = (!rawMsg || rawMsg === "undefined") ? "" : String(rawMsg)
+            const errorDetails = data.details ? " Details=" + data.details : ""
+            if (data.code === 315) {
+              showSyncNotice($("ui.status.auth_error_scope") + errorDetails)
+            } else {
+              showSyncNotice($("ui.status.auth_error", { code: data.code, message: errorMsg + errorDetails }))
+            }
             return
           } else {
             this.isAuth = true


### PR DESCRIPTION
## 问题

Issue #192: 用户在手机端生成授权文件后配置时报错 ，错误信息不清晰，无法帮助用户定位问题。

## 根因分析

1. 当 token 的 scope 不包含  协议权限时，服务端返回 Code=315
2. 服务端响应中  字段可能为 undefined，插件直接拼接导致显示  前缀
3. 原有错误信息  缺乏指导性

## 方案

1. 修复  为 undefined 或字符串 'undefined' 时的处理
2. 针对 Code=315 给出具体的检查指引：
   - Token scope 是否包含 'ws' 协议权限
   - Token scope 是否与客户端类型 (ObsidianPlugin) 匹配
   - Token 创建时是否授予了合适的权限
3. 添加 i18n 支持 (en/zh-CN)

## 测试

- 验证 Code=315 时显示新的引导信息
- 验证其他授权错误码仍正常显示
- 验证 i18n 切换正常