### PR TITLE
fix(sync): handle rename across excluded folder boundary

### DIFF
--- a/src/lib/sync/operator_file.ts
+++ b/src/lib/sync/operator_file.ts
@@ -333,7 +333,28 @@ export const fileRename = async function (file: TAbstractFile, oldfile: string, 
   if (plugin.settings.syncEnabled == false || plugin.settings.readonlySyncEnabled) return
   if (file.path.endsWith(".md")) return
   if (plugin.isIgnoredFile(file.path) && eventEnter) return
-  if (isPathExcluded(file.path, plugin)) return
+  const newExcluded = isPathExcluded(file.path, plugin)
+  const oldExcluded = isPathExcluded(oldfile, plugin)
+
+  // Cross-exclusion-boundary rename handling
+  // 跨排除边界重命名处理
+  if (newExcluded && !oldExcluded) {
+    // Moving from normal folder to excluded folder: delete old path on server
+    // 从正常文件夹移至排除文件夹：删除服务端旧路径
+    void fileDeleteByPath(oldfile, plugin)
+    return
+  }
+  if (!newExcluded && oldExcluded) {
+    // Moving from excluded folder to normal folder: create new file on server
+    // 从排除文件夹移至正常文件夹：在服务端创建新文件
+    void fileModify(file, plugin, true)
+    return
+  }
+  if (newExcluded && oldExcluded) {
+    // Both paths excluded: do nothing
+    // 两个路径均被排除：不处理
+    return
+  }
 
   if (!(file instanceof TFile)) return
 

--- a/src/lib/sync/operator_folder.ts
+++ b/src/lib/sync/operator_folder.ts
@@ -66,12 +66,60 @@ export const folderDelete = async function (folder: TFolder, plugin: FastSync, e
 }
 
 /**
+ * 按路径字符串发送文件夹删除消息（用于无法获取 TFolder 对象的场景，如 rename 后旧路径已不存在）
+ * Send folder delete message by path string (for scenarios where TFolder object is unavailable, e.g., old path after rename)
+ */
+export const folderDeleteByPath = async function (folderPath: string, plugin: FastSync) {
+    if (plugin.settings.syncEnabled == false || plugin.settings.readonlySyncEnabled) return
+    if (isPathExcluded(folderPath, plugin)) return
+    if (plugin.lastSyncPathDeleted.has(folderPath)) return
+
+    await plugin.lockManager.withLock(folderPath, async () => {
+        plugin.addIgnoredFile(folderPath)
+        try {
+            const data = {
+                vault: plugin.settings.vault,
+                path: folderPath,
+                pathHash: hashContent(folderPath),
+            }
+            void plugin.websocket.SendMessage("FolderDelete", data, undefined, () => {
+                plugin.folderSnapshotManager.removeFolder(folderPath)
+            })
+            dump('Folder delete by path send', folderPath)
+        } finally {
+            plugin.removeIgnoredFile(folderPath)
+        }
+    }, { maxRetries: 3, retryInterval: 50 });
+}
+
+/**
  * 文件夹重命名事件处理
  */
 export const folderRename = async function (folder: TFolder, oldPath: string, plugin: FastSync, eventEnter: boolean = false) {
     if (plugin.settings.syncEnabled == false || plugin.settings.readonlySyncEnabled) return
     if (eventEnter && plugin.isIgnoredFile(folder.path)) return
-    if (isPathExcluded(folder.path, plugin)) return
+    const newExcluded = isPathExcluded(folder.path, plugin)
+    const oldExcluded = isPathExcluded(oldPath, plugin)
+
+    // Cross-exclusion-boundary rename handling
+    // 跨排除边界重命名处理
+    if (newExcluded && !oldExcluded) {
+        // Moving from normal folder to excluded folder: delete old path on server
+        // 从正常文件夹移至排除文件夹：删除服务端旧路径
+        void folderDeleteByPath(oldPath, plugin)
+        return
+    }
+    if (!newExcluded && oldExcluded) {
+        // Moving from excluded folder to normal folder: create new folder on server
+        // 从排除文件夹移至正常文件夹：在服务端创建新文件夹
+        void folderModify(folder, plugin, true)
+        return
+    }
+    if (newExcluded && oldExcluded) {
+        // Both paths excluded: do nothing
+        // 两个路径均被排除：不处理
+        return
+    }
 
     // --- 新增：重命名拦截 ---
     if (plugin.lastSyncPathRenamed.has(folder.path)) {

--- a/src/lib/sync/operator_note.ts
+++ b/src/lib/sync/operator_note.ts
@@ -154,7 +154,28 @@ export const noteRename = async function (file: TAbstractFile, oldfile: string, 
   if (!(file instanceof TFile)) return
   if (!file.path.endsWith(".md")) return
   if (eventEnter && plugin.isIgnoredFile(file.path)) return
-  if (isPathExcluded(file.path, plugin)) return
+  const newExcluded = isPathExcluded(file.path, plugin)
+  const oldExcluded = isPathExcluded(oldfile, plugin)
+
+  // Cross-exclusion-boundary rename handling
+  // 跨排除边界重命名处理
+  if (newExcluded && !oldExcluded) {
+    // Moving from normal folder to excluded folder: delete old path on server
+    // 从正常文件夹移至排除文件夹：删除服务端旧路径
+    void noteDeleteByPath(oldfile, plugin)
+    return
+  }
+  if (!newExcluded && oldExcluded) {
+    // Moving from excluded folder to normal folder: create new note on server
+    // 从排除文件夹移至正常文件夹：在服务端创建新笔记
+    void noteModify(file, plugin, true)
+    return
+  }
+  if (newExcluded && oldExcluded) {
+    // Both paths excluded: do nothing
+    // 两个路径均被排除：不处理
+    return
+  }
 
   // --- 新增：重命名拦截 ---
   if (plugin.lastSyncPathRenamed.has(file.path)) {


### PR DESCRIPTION
## Summary / 概述

当用户在 Obsidian 插件端设置中排除某个文件夹后，在该排除文件夹与正常同步文件夹之间移动笔记、附件或文件夹时，“默认同步“会导致同步状态不一致，需要“完整同步”才行：

- 从排除文件夹移动到正常文件夹 → 旧路径在服务端不存在，返回 `Note does not exist` / `File does not exist` 错误
- 从正常文件夹移动到排除文件夹 → 客户端跳过处理，服务端旧记录残留

本 PR 修复了这两种边界情况，通过增加跨排除边界的删除/创建消息来保证同步状态正确。

---

## Root Cause Analysis / 根因分析

### 场景一：排除 → 正常

- **客户端行为**：Obsidian 触发 `rename` 事件，插件发送 `NoteRename`/`FileRename` 消息到服务端。
- **服务端行为**：`Rename` 方法通过 `GetByPathHash` 查找旧路径记录，因旧路径从未同步，返回 `gorm.ErrRecordNotFound`，服务端直接返回 `ErrorNoteNotFound`/`ErrorFileNotFound` 错误。
  （例外：服务端的文件夹 `Rename` 方法不校验旧文件夹记录是否存在，直接创建新路径，所以 排除→正常 能正常创建文件夹）
- **影响**：重命名操作失败，笔记/附件无法同步，需完整同步恢复。

### 场景二：正常 → 排除

- **客户端行为**：Obsidian 触发 `rename` 事件，插件在 `noteRename`/`fileRename`/`folderRename` 函数中检查 `isPathExcluded(newPath, plugin)`，新路径被排除后直接 `return`，不发送任何消息。
- **服务端行为**：服务端未收到任何事件，旧路径记录仍保持 `Action=Create/Modify` 状态。
- **影响**：其他客户端同步时仍会收到旧路径数据，但发起端已无此文件，导致同步状态不一致。

## Solution / 修复方式

修改 `noteRename`、`fileRename`、`folderRename` 函数，增加跨排除边界重命名的处理逻辑：

| 旧路径 | 新路径 | 修复行为                                                     |
| ------ | ------ | ------------------------------------------------------------ |
| 正常   | 排除   | 发送旧路径的 Delete 消息（`noteDeleteByPath`/`fileDeleteByPath`/`folderDeleteByPath`） |
| 排除   | 正常   | 发送新路径的 Modify/Create 消息（`noteModify`/`fileModify`/`folderModify`） |
| 排除   | 排除   | 不处理（两个路径均在排除范围内）                             |
| 正常   | 正常   | 正常重命名（原逻辑不变）                                     |

## Changes / 变更内容

- 修改 `src/lib/note_operator.ts` 中的 `noteRename` 函数，增加排除边界的 Delete/Modify 逻辑
- 修改 `src/lib/file_operator.ts` 中的 `fileRename` 函数，增加排除边界的 Delete/Modify 逻辑
- 修改 `src/lib/folder_operator.ts` 中的 `folderRename` 函数，增加排除边界的 Delete/Modify 逻辑
- 新增 `src/lib/folder_operator.ts` 中的 `folderDeleteByPath` 函数，用于按路径发送 `FolderDelete` 消息

## Test Plan / 测试方式

1. 设置一个排除文件夹 `Excluded`，正常文件夹 `Normal`。
2. 在 `Excluded` 中将 **笔记/附件/文件夹** 移动到正常文件夹 `Normal` → 验证服务端正确创建了 **笔记/附件/文件夹** 。
3. 在 `Normal` 中将 **笔记/附件/文件夹** 移动到 `Excluded` → 验证服务端正确删除了 **笔记/附件/文件夹**。
4. 确认排除→排除、正常→正常场景的行为未受影响

### 个人测试

插件设置：
<img width="500"  alt="排除文件夹设置" src="https://github.com/user-attachments/assets/0d1dda54-8b6b-4b75-b730-bc71780daafb" />

修复前（视频）：
https://github.com/user-attachments/assets/e9dc9988-e6fd-489f-8b19-542340ea887d

修复后（视频）：
https://github.com/user-attachments/assets/a449dbf7-b2aa-430a-b34a-b1046046fad1


## For Reviewer / 给审查者

- 验证 `noteRename`、`fileRename`、`folderRename` 中对路径排除状态的判断逻辑是否正确（四种组合）
- 验证新增的 `folderDeleteByPath` 是否与已有的 `noteDeleteByPath`/`fileDeleteByPath` 行为一致
- 确认移动操作后，服务端和客户端的状态是否最终收敛为预期状态
