### PR TITLE
fix: 修复同步状态指示器传输结束后仍持续旋转的问题

### DIFF
--- a/src/lib/sync/concurrency_limiter.ts
+++ b/src/lib/sync/concurrency_limiter.ts
@@ -121,8 +121,4 @@ export class ConcurrencyLimiter {
         this.queue = [];
     }
 
-    /** 是否有待确认的操作（等待服务端 ACK）/ Whether there are pending operations awaiting ACK */
-    public hasPending(): boolean {
-        return this.activeKeys.size > 0 || this.queue.length > 0;
-    }
 }

--- a/src/lib/sync/operator_file.ts
+++ b/src/lib/sync/operator_file.ts
@@ -859,6 +859,9 @@ export const receiveFileSyncMtime = async function (data: ReceiveMtimeMessage, p
     }
   });
 
+  // FileSyncMtime 表示文件已在服务端存在（无需上传），释放 fileModify 中获取的并发槽位
+  // FileSyncMtime indicates file already exists on server (no upload needed), release slot acquired by fileModify
+  if (data.path) plugin.concurrencyLimiter.releaseSlot(data.path)
   plugin.fileSyncTasks.completed++
 }
 

--- a/src/lib/sync/operator_note.ts
+++ b/src/lib/sync/operator_note.ts
@@ -612,6 +612,10 @@ export const receiveNoteDeleteAck = function (data: { lastTime?: number; path?: 
   if (data.path && plugin.pendingNoteDeleteAcks.has(data.path)) {
     plugin.fileHashManager.removeFileHash(data.path)
     plugin.pendingNoteDeleteAcks.delete(data.path)
+  }
+  // 释放并发槽位：与 FileDeleteAck/ConfigDeleteAck 保持一致，仅检查 data.path 是否存在
+  // Release concurrency slot: consistent with FileDeleteAck/ConfigDeleteAck, only check data.path
+  if (data.path) {
     plugin.concurrencyLimiter.releaseSlot(data.path)
   }
   if (data.lastTime && data.lastTime > Number(plugin.localStorageManager.getMetadata("lastNoteSyncTime"))) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -406,19 +406,12 @@ export default class FastSync extends Plugin {
 
       // 注册 WebSocket 数据传输活动监听 — 任何数据收发时显示同步指示器 / Register data transfer activity listener
       let activityTimer: number | null = null;
-      const scheduleTurnOff = () => {
-        if (activityTimer) window.clearTimeout(activityTimer);
-        activityTimer = window.setTimeout(() => {
-          if (this.concurrencyLimiter.hasPending()) {
-            scheduleTurnOff(); // 还有未确认操作，200ms 后再检查 / Still pending ACKs, recheck
-          } else {
-            this.menuManager.setSyncStatus(false);
-          }
-        }, 600);
-      };
       this.websocket.addActivityListener(() => {
         this.menuManager.setSyncStatus(true);
-        scheduleTurnOff();
+        if (activityTimer) window.clearTimeout(activityTimer);
+        activityTimer = window.setTimeout(() => {
+          this.menuManager.setSyncStatus(false);
+        }, 1000);
       });
 
       // 初始化分享指示器管理器 / Initialize share indicator manager

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -56,7 +56,7 @@
   }
 
   to {
-    transform: rotate(-360deg);
+    transform: rotate(360deg);
   }
 }
 

--- a/styles.css
+++ b/styles.css
@@ -48,7 +48,7 @@
     transform: rotate(0deg);
   }
   to {
-    transform: rotate(-360deg);
+    transform: rotate(360deg);
   }
 }
 /* 同步中：wifi 图标上叠加旋转 refresh-cw 图标 / Syncing: spinning refresh-cw icon overlay */


### PR DESCRIPTION
## 问题

同步状态指示器（spinner）在传输完成后仍然持续旋转不停止。

## 根因

spinner 关停逻辑依赖 `concurrencyLimiter.hasPending()` 判断是否还有待确认的操作。但并发槽位释放路径存在多个缺口，导致 `hasPending()` 永远返回 true，spinner 永转。

## 修复方案

**核心**: 将 spinner 关停从依赖 `concurrencyLimiter.hasPending()` 改为纯活动驱动——最后一条 WS 消息收发后 1 秒无新活动即自动停止。

**配套修复**:
- `receiveNoteDeleteAck`: 将 `releaseSlot` 从 pending 检查内部移到外部，与 `FileDeleteAck`/`ConfigDeleteAck` 保持一致
- `receiveFileSyncMtime`: 增加 slot 释放，修复 `fileModify` 中 slot 未被释放的资源泄漏
- 删除 `hasPending()` 方法（已无调用者）

## 变更

| 文件 | 说明 |
|------|------|
| main.ts | 简化 spinner 关停逻辑，去掉递归检查 |
| concurrency_limiter.ts | 删除 hasPending() |
| operator_note.ts | NoteDeleteAck slot 释放修复 |
| operator_file.ts | FileSyncMtime slot 释放修复 |