### PR TITLE
fix: share icon leak to sibling folders

### DIFF
--- a/src/lib/ui/share_indicator_manager.ts
+++ b/src/lib/ui/share_indicator_manager.ts
@@ -88,9 +88,15 @@ export class ShareIndicatorManager {
                 if (targetEl.getAttribute('data-fns-shared') !== 'true') {
                     targetEl.setAttribute('data-fns-shared', 'true');
                 }
+                if (el.getAttribute('data-fns-shared') !== 'true') {
+                    el.setAttribute('data-fns-shared', 'true');
+                }
             } else {
                 if (targetEl.hasAttribute('data-fns-shared')) {
                     targetEl.removeAttribute('data-fns-shared');
+                }
+                if (el.hasAttribute('data-fns-shared')) {
+                    el.removeAttribute('data-fns-shared');
                 }
             }
         });

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -2867,9 +2867,7 @@ body .suggestion-container {
 .fns-v-align-middle { vertical-align: middle; }
 
 /* Share Indicator (Data Attribute based) */
-.nav-file[data-fns-shared="true"] .nav-file-title-content::before,
 .nav-file-title[data-fns-shared="true"] .nav-file-title-content::before,
-.nav-folder[data-fns-shared="true"] .nav-folder-title-content::before,
 .nav-folder-title[data-fns-shared="true"] .nav-folder-title-content::before,
 [data-drag-path][data-fns-shared="true"] .nn-navitem-name::before,
 [data-drag-path][data-fns-shared="true"] .nn-file-name::before {

--- a/styles.css
+++ b/styles.css
@@ -2785,9 +2785,7 @@ body .suggestion-container {
 }
 
 /* Share Indicator (Data Attribute based) */
-.nav-file[data-fns-shared=true] .nav-file-title-content::before,
 .nav-file-title[data-fns-shared=true] .nav-file-title-content::before,
-.nav-folder[data-fns-shared=true] .nav-folder-title-content::before,
 .nav-folder-title[data-fns-shared=true] .nav-folder-title-content::before,
 [data-drag-path][data-fns-shared=true] .nn-navitem-name::before,
 [data-drag-path][data-fns-shared=true] .nn-file-name::before {


### PR DESCRIPTION
## 问题

当某文件夹下的笔记分享时，同级（非分享路径上）文件夹也会错误显示分享图标。

## 根因

1. **CSS 选择器过于宽泛** — `.nav-folder[data-fns-shared=true] .nav-folder-title-content::before` 使用后代选择器，匹配了父文件夹内所有子文件夹的标题
2. **data-fns-shared 未设置到标题元素** — 属性只设在 `.nav-folder` 父元素上，标题级选择器从未生效

## 修复

| 文件 | 改动 |
|---|---|
| `share_indicator_manager.ts` | 设置/移除 `data-fns-shared` 时同时操作标题元素自身 |
| `styles.scss` / `styles.css` | 移除宽泛的父级选择器，仅保留标题级选择器 |

## 测试
修复前：
<img width="208" height="89" alt="2026-06-10_173034" src="https://github.com/user-attachments/assets/f86231bf-131d-4174-bebe-14d7a0b2e702" />
修复后：
<img width="185" height="92" alt="2026-06-10_172833" src="https://github.com/user-attachments/assets/a56610de-b823-496c-a21a-d46e7c461f07" />
