### PR TITLE
点击 ribbon 按钮"默认同步"和"完整同步"时，触发重连，避免只能干等退避到时

### DIFF
--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -218,6 +218,7 @@ export default {
   "ui.menu.default_sync_desc": "Check incremental updates since the last sync",
   "ui.menu.full_sync": "Full Sync",
   "ui.menu.full_sync_desc": "Performs a full comparison with the server, syncs all files, and cleans up all empty local folders",
+  "ui.menu.reconnecting": "Reconnecting, sync will start automatically once connected...",
   "ui.menu.enable_sync": "Enable Sync",
   "ui.menu.enable_sync_desc": "All configured syncs are currently enabled.",
   "ui.menu.disable_sync": "Temporarily Disable Sync",

--- a/src/i18n/locales/ja.ts
+++ b/src/i18n/locales/ja.ts
@@ -215,6 +215,7 @@ export default {
   "ui.menu.default_sync_desc": "上次同期以降の増分更新を確認します",
   "ui.menu.full_sync": "完全同期",
   "ui.menu.full_sync_desc": "サーバーと完全に比較し、すべてのファイルを同期すると同時に、ローカルのすべての空フォルダを削除します",
+  "ui.menu.reconnecting": "再接続中、接続が成功すると自動的に同期されます...",
   "ui.menu.enable_sync": "同期を有効化",
   "ui.menu.enable_sync_desc": "設定で有効にしたすべての同期",
   "ui.menu.disable_sync": "一時的に同期を無効化",

--- a/src/i18n/locales/ko.ts
+++ b/src/i18n/locales/ko.ts
@@ -215,6 +215,7 @@ export default {
   "ui.menu.default_sync_desc": "마지막 동기화 이후의 증분 업데이트 확인",
   "ui.menu.full_sync": "전체 동기화",
   "ui.menu.full_sync_desc": "서버와 전체 비교를 수행하여 모든 파일을 동기화하고 로컬의 모든 빈 폴더를 정리합니다",
+  "ui.menu.reconnecting": "다시 연결 중, 연결 성공 시 자동으로 동기화됩니다...",
   "ui.menu.enable_sync": "동기화 활성화",
   "ui.menu.enable_sync_desc": "설정된 모든 동기화가 활성화되어 있습니다.",
   "ui.menu.disable_sync": "동기화 일시 중지",

--- a/src/i18n/locales/zh-CN.ts
+++ b/src/i18n/locales/zh-CN.ts
@@ -218,6 +218,7 @@ export default {
   "ui.menu.default_sync_desc": "检查上次同步以来的增量更新",
   "ui.menu.full_sync": "完整同步",
   "ui.menu.full_sync_desc": "会和服务端进行完整比对，同步所有文件，同时清理本地所有空文件夹",
+  "ui.menu.reconnecting": "正在重新连接，连接成功后将自动同步...",
   "ui.menu.enable_sync": "开启同步",
   "ui.menu.enable_sync_desc": "已经开启设置的所有同步",
   "ui.menu.disable_sync": "临时关闭同步",

--- a/src/i18n/locales/zh-TW.ts
+++ b/src/i18n/locales/zh-TW.ts
@@ -218,6 +218,7 @@ export default {
   "ui.menu.default_sync_desc": "檢查上次同步以來的增量更新",
   "ui.menu.full_sync": "完整同步",
   "ui.menu.full_sync_desc": "會和服務端進行完整比對，同步所有檔案，同時清理本地所有空資料夾",
+  "ui.menu.reconnecting": "正在重新連線，連線成功後將自動同步...",
   "ui.menu.enable_sync": "開啟同步",
   "ui.menu.enable_sync_desc": "已啟用設定中的所有同步",
   "ui.menu.disable_sync": "臨時關閉同步",

--- a/src/lib/sync/operator.ts
+++ b/src/lib/sync/operator.ts
@@ -418,7 +418,11 @@ export const handleSync = async function (plugin: FastSync, isLoadLastTime: bool
     plugin.syncState.activeSyncContext = context; // 记录活跃的同步上下文 / Record the active sync context
     dump(`Sync context generated: ${context}`);
     if (!plugin.menuManager.ribbonIconStatus) {
-      showSyncNotice($("setting.remote.disconnected"));
+      // WebSocket 处于断开/退避状态，立即触发重连，连接成功后自动执行同步
+      // WebSocket is disconnected/in backoff, trigger immediate reconnect and auto-sync on connect
+      plugin.syncState.pendingSyncType = isLoadLastTime ? 'incremental' : 'full';
+      plugin.websocket.triggerReconnect();
+      showSyncNotice($("ui.menu.reconnecting"));
       plugin.syncState.activeSyncContext = null; // 早期退出，清空上下文 / Early return, reset the context
       return;
     }

--- a/src/lib/sync/sync_state.ts
+++ b/src/lib/sync/sync_state.ts
@@ -34,6 +34,9 @@ export class SyncState {
   currentSyncType: "full" | "incremental" = "incremental";
   /** 当前活跃的同步上下文 UUID / Current active sync context UUID */
   activeSyncContext: string | null = null;
+  /** 用户通过 ribbon 手动触发的待执行同步类型（断开时暂存，重连成功后执行）
+   *  Pending sync type triggered manually via ribbon (stored when disconnected, executed after reconnect) */
+  pendingSyncType: 'incremental' | 'full' | null = null;
 
   // ─── Per-type sync task statistics ───────────────────────────────────────────
   noteSyncTasks: SyncTaskStats = { needUpload: 0, needModify: 0, needSyncMtime: 0, needDelete: 0, completed: 0 };

--- a/src/lib/sync/websocket_manager.ts
+++ b/src/lib/sync/websocket_manager.ts
@@ -3,7 +3,7 @@ import { moment, Platform } from "obsidian";
 import { handleFileChunkDownload, BINARY_PREFIX_FILE_SYNC, clearUploadQueue } from "./operator_file";
 import { dump, addRandomParam, showSyncNotice, safeStringify } from "../utils/helpers";
 import { enSendDTOToProtobuf, deReceivePacket } from "../../pb/protobuf_mapper";
-import { receiveOperators, startupSync } from "./operator";
+import { receiveOperators, startupSync, startupFullSync } from "./operator";
 import { SyncLogManager } from "./sync_log_manager";
 import * as WSAction from "./websocket_action";
 import { WebSocketClient } from "./websocket_client";
@@ -343,12 +343,32 @@ export class WebSocketManager {
     this.plugin.isFirstSync = true;
     this.plugin.isWatchEnabled = true;
 
+    // 检查是否有用户手动触发的待执行同步 / Check if user manually triggered a pending sync
+    const pendingType = this.plugin.syncState.pendingSyncType;
+    this.plugin.syncState.pendingSyncType = null;
+
     if (this.plugin.settings.manualSyncEnabled) {
-      dump("Full Manual Sync Mode enabled, skipping startup sync");
+      // 如果用户手动触发了同步，即使 manualSyncEnabled 也执行一次
+      // If user manually triggered sync, execute once even with manualSyncEnabled
+      if (pendingType) {
+        if (pendingType === 'full') {
+          startupFullSync(this.plugin);
+        } else {
+          startupSync(this.plugin);
+        }
+      } else {
+        dump("Full Manual Sync Mode enabled, skipping startup sync");
+      }
       return;
     }
 
-    startupSync(this.plugin);
+    // 有 pending 同步请求时，使用 pending 的类型；否则走默认增量同步
+    // If pending sync requested, use its type; otherwise default incremental
+    if (pendingType === 'full') {
+      startupFullSync(this.plugin);
+    } else {
+      startupSync(this.plugin);
+    }
   }
 
   private handleConflictError(data: StructuredMessageData) {


### PR DESCRIPTION
## 摘要

当前点击 ribbon 菜单的"默认同步"或"完整同步"时，如果 WebSocket 处于断开或退避等待状态，仅提示"服务已断开"并退出，不会触发重连。用户只能被动等待退避（最长 30 分钟）自然到期，或通过切换网络/切回前台等间接方式触发 `triggerReconnect()`。

此 PR 改进：当用户主动点击 ribbon 同步按钮时，如果连接断开，**立即跳过退避算法并触发重连**，连接成功后自动执行用户选择的同步类型。

## 改动

- **`sync_state.ts`** — 新增 `pendingSyncType` 字段，暂存用户通过 ribbon 触发的同步意图（`incremental` / `full`）
- **`operator.ts`** — `handleSync()` 中 WebSocket 断开时：设置 `pendingSyncType` → 调用 `triggerReconnect()` 立即重连 → 提示"正在重新连接..." → 正常退出清理
- **`websocket_manager.ts`** — `StartHandle()` 连接成功后消费 `pendingSyncType`，执行对应类型的同步（完整/增量）；`manualSyncEnabled` 模式下，用户手动触发时仍然执行一次同步
- **`i18n`** — 5 个语言文件新增 `ui.menu.reconnecting` 提示文本

## 执行流程

```
用户点击 "完整同步"（WebSocket 断开中）
  → handleSync 检测到 ribbonIconStatus === false
  → syncState.pendingSyncType = 'full'
  → websocket.triggerReconnect()        // 重置退避计数器，立即发起连接
  → 提示 "正在重新连接，连接成功后将自动同步..."
  → return

WebSocket 连接 → 鉴权 → StartHandle()
  → 检查 pendingSyncType === 'full'
  → startupFullSync()                    // 执行用户选择的完整同步
```

## 测试方式

1. 断开网络，等待 ribbon 图标变为 wifi-off
2. 点击 ribbon → "完整同步" → 应提示"正在重新连接..."而非"服务已断开"
3. 恢复网络 → WebSocket 自动重连 → 应执行完整同步
4. 已连接状态下点击 → 行为不变，直接走原有流程