### PR TITLE
fix: 移动端 localStorage 被系统清除导致每次启动全量重算哈希 + 大文件跳过通知重复弹

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "fix": "eslint --fix src",
     "build": "tsc -noEmit -skipLibCheck && node esbuild.config.mjs production",
     "test:auth": "node tests/websocket-auth-error.test.mjs",
+    "test:mirror": "node tests/file-mirror-restore.test.mjs",
     "ver": "node ./scripts/update-version.js",
     "dist": "npx tsx scripts/copy-dist.ts",
     "translate": "node scripts/translate-i18n.mjs --model Qwen/Qwen3.6-35B-A3B",

--- a/src/lib/storage/config_hash_manager.ts
+++ b/src/lib/storage/config_hash_manager.ts
@@ -1,6 +1,6 @@
 import { normalizePath } from "obsidian";
 
-import { hashContentAsync, dump, dumpError, configIsPathExcluded, getConfigSyncCustomDirs, showSyncNotice, hashFileAsync } from "../utils/helpers";
+import { hashContentAsync, dump, dumpError, configIsPathExcluded, getConfigSyncCustomDirs, showSyncNotice, hashFileAsync, LocalStateFileMirror } from "../utils/helpers";
 import { configAllPaths } from "../sync/operator_config";
 import type FastSync from "../../main";
 
@@ -23,17 +23,29 @@ export class ConfigHashManager {
     private hashMap: Map<string, HashCache> = new Map();
     private storageKey: string;
     private isInitialized: boolean = false;
+    // 文件镜像：localStorage 被移动端系统清除后的兜底恢复
+    // File mirror: fallback recovery after mobile OS clears localStorage
+    private mirror: LocalStateFileMirror;
 
     constructor(plugin: FastSync) {
         this.plugin = plugin;
-        // 根据仓库名生成唯一的存储键
-        const vaultName = this.plugin.app.vault.getName();
-        this.storageKey = `fns-${vaultName}-configHashMap`;
+        // 与 vault 名无关的稳定存储键：iCloud 手机端同步冲突会把库文件夹改名，绑定 vault 名的旧 key
+        // 会失效导致哈希表意外重建，历史键迁移见 loadFromStorage
+        this.storageKey = `fns-configHashMap`;
+        this.mirror = new LocalStateFileMirror(plugin, "configHashMap.json");
+    }
+
+    /**
+     * 立即落盘防抖中的镜像写（用于同步结束、插件卸载等需要保证持久化的时机）
+     */
+    flush(): void {
+        this.mirror.flush();
     }
 
     /**
      * 初始化哈希表
-     * 只在 localStorage 不存在时执行完整的配置文件遍历
+     * 只在 localStorage 不存在时执行完整的配置文件遍历；localStorage 未命中时先尝试文件镜像恢复，
+     * 镜像也没有才真正重建
      */
     async initialize(): Promise<void> {
         dump("ConfigHashManager: 开始初始化");
@@ -44,11 +56,21 @@ export class ConfigHashManager {
         if (loaded) {
             dump(`ConfigHashManager: 从 localStorage 加载成功,共 ${this.hashMap.size} 个配置`);
             this.isInitialized = true;
-        } else {
-            dump("ConfigHashManager: localStorage 中无数据,开始构建配置哈希映射");
-            await this.buildConfigHashMap();
-            this.isInitialized = true;
+            return;
         }
+
+        // localStorage 未命中：尝试从文件镜像恢复，不弹通知、不重建
+        const mirrored = await this.mirror.read();
+        if (mirrored && this.parseAndLoad(mirrored)) {
+            dump("ConfigHashManager: 从文件镜像恢复哈希表");
+            this.saveToStorage();
+            this.isInitialized = true;
+            return;
+        }
+
+        dump("ConfigHashManager: localStorage 与文件镜像均无数据,开始构建配置哈希映射");
+        await this.buildConfigHashMap();
+        this.isInitialized = true;
     }
 
     /**
@@ -223,24 +245,18 @@ export class ConfigHashManager {
         try {
             let data = this.plugin.app.loadLocalStorage(this.storageKey) as string | null;
 
-            // 迁移逻辑：如果新键无数据，尝试读取旧键
+            // 迁移逻辑：如果新键无数据，按由新到旧依次回溯历史键格式
             if (!data) {
                 const vaultName = this.plugin.app.vault.getName();
-
-                // 1. 尝试上一个格式: fast-note-sync-[Vault]-configHashMap
-                const prevKey1 = `fast-note-sync-${vaultName}-configHashMap`;
-                data = this.plugin.app.loadLocalStorage(prevKey1) as string | null;
-
-                // 2. 尝试更早格式: fast-note-sync-[Vault]-config-hash-map
-                if (!data) {
-                    const prevKey2 = `fast-note-sync-${vaultName}-config-hash-map`;
-                    data = this.plugin.app.loadLocalStorage(prevKey2) as string | null;
-                }
-
-                // 3. 尝试最原始格式: fast-note-sync-config-hash-map-[Vault]
-                if (!data) {
-                    const oldKey = `fast-note-sync-config-hash-map-${vaultName}`;
-                    data = this.plugin.app.loadLocalStorage(oldKey) as string | null;
+                const legacyKeys = [
+                    `fns-${vaultName}-configHashMap`,                     // 上一版：绑定本地库名
+                    `fast-note-sync-${vaultName}-configHashMap`,          // 更早版
+                    `fast-note-sync-${vaultName}-config-hash-map`,        // 更更早版
+                    `fast-note-sync-config-hash-map-${vaultName}`,        // 最原始格式
+                ];
+                for (const legacyKey of legacyKeys) {
+                    data = this.plugin.app.loadLocalStorage(legacyKey) as string | null;
+                    if (data) break;
                 }
 
                 if (data) {
@@ -251,6 +267,18 @@ export class ConfigHashManager {
                 }
             }
 
+            return this.parseAndLoad(data);
+        } catch (error) {
+            dump("ConfigHashManager: 从 localStorage 加载失败", error);
+            return false;
+        }
+    }
+
+    /**
+     * 解析哈希表数据并装入 this.hashMap，兼容旧版仅存哈希字符串的格式
+     */
+    private parseAndLoad(data: string): boolean {
+        try {
             const parsed = JSON.parse(data) as Record<string, unknown>;
             const migratedMap = new Map<string, HashCache>();
             let needsSave = false;
@@ -269,24 +297,34 @@ export class ConfigHashManager {
 
             return true;
         } catch (error) {
-            dump("ConfigHashManager: 从 localStorage 加载失败", error);
+            dump("ConfigHashManager: 解析哈希表数据失败", error);
             return false;
         }
     }
 
     /**
-     * 保存哈希映射到 localStorage
+     * 保存哈希映射到 localStorage，同时镜像写入文件 (兜底移动端 localStorage 被清除)
      */
     private saveToStorage(): void {
+        let data: string;
         try {
             const obj = Object.fromEntries(this.hashMap);
-            const data = JSON.stringify(obj);
+            data = JSON.stringify(obj);
+        } catch (error) {
+            dump("ConfigHashManager: 序列化哈希表失败", error);
+            return;
+        }
+
+        try {
             this.plugin.app.saveLocalStorage(this.storageKey, data);
         } catch (error) {
             dump("ConfigHashManager: 保存到 localStorage 失败", error);
             const errorMsg = error instanceof Error ? error.message : String(error);
             showSyncNotice(`保存配置哈希映射失败: ${errorMsg}`);
         }
+
+        // 即使 localStorage 写入失败 (如配额)，镜像写入也照常进行
+        this.mirror.scheduleWrite(data);
     }
 
     /**

--- a/src/lib/storage/file_hash_manager.ts
+++ b/src/lib/storage/file_hash_manager.ts
@@ -1,4 +1,4 @@
-import { hashContentAsync, dump, isPathExcluded, showSyncNotice, isLargeBinarySyncRisk, describeBinarySyncLimit, logMemorySnapshot, hashFileAsync } from "../utils/helpers";
+import { hashContentAsync, dump, isPathExcluded, showSyncNotice, isLargeBinarySyncRisk, describeBinarySyncLimit, logMemorySnapshot, hashFileAsync, LocalStateFileMirror } from "../utils/helpers";
 import type FastSync from "../../main";
 
 
@@ -20,17 +20,33 @@ export class FileHashManager {
   private hashMap: Map<string, HashCache> = new Map();
   private storageKey: string;
   private isInitialized: boolean = false;
+  // 文件镜像：localStorage 被移动端系统清除后的兜底恢复
+  // File mirror: fallback recovery after mobile OS clears localStorage
+  private mirror: LocalStateFileMirror;
 
   constructor(plugin: FastSync) {
     this.plugin = plugin;
-    // 根据仓库名生成唯一的存储键 (格式: fns-[VaultName]-fileHashMap)
-    const vaultName = this.plugin.app.vault.getName();
-    this.storageKey = `fns-${vaultName}-fileHashMap`;
+    // 与 vault 名无关的稳定存储键：iCloud 手机端同步冲突会把库文件夹改名（"Vault 1" 等），
+    // 绑定 vault 名的旧 key 会失效导致哈希表意外重建，历史键迁移见 loadFromStorage
+    // Stable storage key independent of the vault name: iCloud sync conflicts on mobile often rename
+    // the vault folder ("Vault 1" etc), invalidating vault-name-bound keys and causing unexpected
+    // rebuilds. Legacy key migration lives in loadFromStorage.
+    this.storageKey = `fns-fileHashMap`;
+    this.mirror = new LocalStateFileMirror(plugin, "fileHashMap.json");
+  }
+
+  /**
+   * 立即落盘防抖中的镜像写（用于同步结束、插件卸载等需要保证持久化的时机）
+   * Flush any pending debounced mirror write (call at sync end / plugin unload)
+   */
+  flush(): void {
+    this.mirror.flush();
   }
 
   /**
    * 初始化哈希表
-   * 只在 localStorage 不存在时执行完整的文件遍历
+   * 只在 localStorage 不存在时执行完整的文件遍历；localStorage 未命中时先尝试文件镜像恢复，
+   * 镜像也没有才真正重建（移动端 localStorage 被系统清除时避免每次启动全量重建 + 弹通知）
    */
   async initialize(): Promise<void> {
     dump("FileHashManager: 开始初始化");
@@ -41,11 +57,22 @@ export class FileHashManager {
     if (loaded) {
       dump(`FileHashManager: 从 localStorage 加载成功,共 ${this.hashMap.size} 个文件`);
       this.isInitialized = true;
-    } else {
-      dump("FileHashManager: localStorage 中无数据,开始构建哈希映射");
-      await this.buildFileHashMap();
-      this.isInitialized = true;
+      return;
     }
+
+    // localStorage 未命中：尝试从文件镜像恢复，不弹通知、不重建
+    // localStorage miss: try restoring from the file mirror first — no notice, no rebuild
+    const mirrored = await this.mirror.read();
+    if (mirrored && this.parseAndLoad(mirrored)) {
+      dump("FileHashManager: 从文件镜像恢复哈希表");
+      this.saveToStorage();
+      this.isInitialized = true;
+      return;
+    }
+
+    dump("FileHashManager: localStorage 与文件镜像均无数据,开始构建哈希映射");
+    await this.buildFileHashMap();
+    this.isInitialized = true;
   }
 
   /**
@@ -199,24 +226,18 @@ export class FileHashManager {
     try {
       let data = this.plugin.app.loadLocalStorage(this.storageKey) as string | null;
 
-      // 迁移逻辑：如果新键无数据，尝试读取旧键
+      // 迁移逻辑：如果新键无数据，按由新到旧依次回溯历史键格式
       if (!data) {
         const vaultName = this.plugin.app.vault.getName();
-
-        // 1. 尝试上一个格式: fast-note-sync-[Vault]-fileHashMap
-        const prevKey1 = `fast-note-sync-${vaultName}-fileHashMap`;
-        data = this.plugin.app.loadLocalStorage(prevKey1) as string | null;
-
-        // 2. 尝试更早格式: fast-note-sync-[Vault]-file-hash-map
-        if (!data) {
-          const prevKey2 = `fast-note-sync-${vaultName}-file-hash-map`;
-          data = this.plugin.app.loadLocalStorage(prevKey2) as string | null;
-        }
-
-        // 3. 尝试最原始格式: fast-note-sync-file-hash-map-[Vault]
-        if (!data) {
-          const oldKey = `fast-note-sync-file-hash-map-${vaultName}`;
-          data = this.plugin.app.loadLocalStorage(oldKey) as string | null;
+        const legacyKeys = [
+          `fns-${vaultName}-fileHashMap`,                      // 上一版：绑定本地库名
+          `fast-note-sync-${vaultName}-fileHashMap`,           // 更早版
+          `fast-note-sync-${vaultName}-file-hash-map`,         // 更更早版
+          `fast-note-sync-file-hash-map-${vaultName}`,         // 最原始格式
+        ];
+        for (const legacyKey of legacyKeys) {
+          data = this.plugin.app.loadLocalStorage(legacyKey) as string | null;
+          if (data) break;
         }
 
         if (data) {
@@ -227,6 +248,19 @@ export class FileHashManager {
         }
       }
 
+      return this.parseAndLoad(data);
+    } catch (error) {
+      dump("FileHashManager: 从 localStorage 加载失败", error);
+      return false;
+    }
+  }
+
+  /**
+   * 解析哈希表数据并装入 this.hashMap，兼容旧版仅存哈希字符串的格式
+   * Parse hash map data and load it into this.hashMap, compatible with the old hash-only string format
+   */
+  private parseAndLoad(data: string): boolean {
+    try {
       const parsed = JSON.parse(data) as Record<string, unknown>;
       // 数据迁移逻辑：如果值是字符串，说明是旧版数据，需要重新构建或设为默认值
       // Data migration: if value is string, it's old version data; need to migrate or default
@@ -250,24 +284,35 @@ export class FileHashManager {
 
       return true;
     } catch (error) {
-      dump("FileHashManager: 从 localStorage 加载失败", error);
+      dump("FileHashManager: 解析哈希表数据失败", error);
       return false;
     }
   }
 
   /**
-   * 保存哈希映射到 localStorage
+   * 保存哈希映射到 localStorage，同时镜像写入文件 (兜底移动端 localStorage 被清除)
    */
   private saveToStorage(): void {
+    let data: string;
     try {
       const obj = Object.fromEntries(this.hashMap);
-      const data = JSON.stringify(obj);
+      data = JSON.stringify(obj);
+    } catch (error) {
+      dump("FileHashManager: 序列化哈希表失败", error);
+      return;
+    }
+
+    try {
       this.plugin.app.saveLocalStorage(this.storageKey, data);
     } catch (error) {
       dump("FileHashManager: 保存到 localStorage 失败", error);
       const msg = error instanceof Error ? error.message : String(error);
       showSyncNotice(`保存文件哈希映射失败: ${msg}`);
     }
+
+    // 即使 localStorage 写入失败 (如配额)，镜像写入也照常进行
+    // Mirror write proceeds even if the localStorage write failed (e.g. quota)
+    this.mirror.scheduleWrite(data);
   }
 
   /**

--- a/src/lib/storage/folder_snapshot_manager.ts
+++ b/src/lib/storage/folder_snapshot_manager.ts
@@ -1,6 +1,6 @@
 import { TFolder } from "obsidian";
 
-import { dump, isFolderSyncPathExcluded } from "../utils/helpers";
+import { dump, isFolderSyncPathExcluded, LocalStateFileMirror } from "../utils/helpers";
 import type FastSync from "../../main";
 
 
@@ -14,24 +14,47 @@ export class FolderSnapshotManager {
     private snapshotMap: Map<string, number> = new Map();
     private storageKey: string;
     private isInitialized: boolean = false;
+    // 文件镜像：localStorage 被移动端系统清除后的兜底恢复
+    // File mirror: fallback recovery after mobile OS clears localStorage
+    private mirror: LocalStateFileMirror;
 
     constructor(plugin: FastSync) {
         this.plugin = plugin;
-        const vaultName = this.plugin.app.vault.getName();
-        this.storageKey = `fns-${vaultName}-folderSnapshot`;
+        // 与 vault 名无关的稳定存储键：iCloud 手机端同步冲突会把库文件夹改名，绑定 vault 名的旧 key
+        // 会失效导致快照意外重建，历史键迁移见 loadFromStorage
+        this.storageKey = `fns-folderSnapshot`;
+        this.mirror = new LocalStateFileMirror(plugin, "folderSnapshot.json");
+    }
+
+    /**
+     * 立即落盘防抖中的镜像写（用于同步结束、插件卸载等需要保证持久化的时机）
+     */
+    flush(): void {
+        this.mirror.flush();
     }
 
     /**
      * 初始化快照表
+     * localStorage 未命中时先尝试文件镜像恢复，镜像也没有才真正重建
      */
     async initialize(): Promise<void> {
         const loaded = this.loadFromStorage();
         if (loaded) {
             this.isInitialized = true;
-        } else {
-            await this.buildSnapshot();
-            this.isInitialized = true;
+            return;
         }
+
+        // localStorage 未命中：尝试从文件镜像恢复
+        const mirrored = await this.mirror.read();
+        if (mirrored && this.parseAndLoad(mirrored)) {
+            dump("FolderSnapshotManager: 从文件镜像恢复快照");
+            this.saveToStorage();
+            this.isInitialized = true;
+            return;
+        }
+
+        await this.buildSnapshot();
+        this.isInitialized = true;
     }
 
     isReady(): boolean {
@@ -122,24 +145,18 @@ export class FolderSnapshotManager {
         try {
             let data = this.plugin.app.loadLocalStorage(this.storageKey) as string | null;
 
-            // 迁移逻辑：如果新键无数据，尝试读取旧键
+            // 迁移逻辑：如果新键无数据，按由新到旧依次回溯历史键格式
             if (!data) {
                 const vaultName = this.plugin.app.vault.getName();
-
-                // 1. 尝试上一个格式: fast-note-sync-[Vault]-folderSnapshot
-                const prevKey1 = `fast-note-sync-${vaultName}-folderSnapshot`;
-                data = this.plugin.app.loadLocalStorage(prevKey1) as string | null;
-
-                // 2. 尝试更早格式: fast-note-sync-[Vault]-folder-snapshot
-                if (!data) {
-                    const prevKey2 = `fast-note-sync-${vaultName}-folder-snapshot`;
-                    data = this.plugin.app.loadLocalStorage(prevKey2) as string | null;
-                }
-
-                // 3. 尝试最原始格式: fast-note-sync-folder-snapshot-[Vault]
-                if (!data) {
-                    const oldKey = `fast-note-sync-folder-snapshot-${vaultName}`;
-                    data = this.plugin.app.loadLocalStorage(oldKey) as string | null;
+                const legacyKeys = [
+                    `fns-${vaultName}-folderSnapshot`,                    // 上一版：绑定本地库名
+                    `fast-note-sync-${vaultName}-folderSnapshot`,         // 更早版
+                    `fast-note-sync-${vaultName}-folder-snapshot`,        // 更更早版
+                    `fast-note-sync-folder-snapshot-${vaultName}`,        // 最原始格式
+                ];
+                for (const legacyKey of legacyKeys) {
+                    data = this.plugin.app.loadLocalStorage(legacyKey) as string | null;
+                    if (data) break;
                 }
 
                 if (data) {
@@ -149,11 +166,7 @@ export class FolderSnapshotManager {
                     return false;
                 }
             }
-            const parsed = JSON.parse(data) as Record<string, number>;
-            this.snapshotMap = new Map(
-                Object.entries(parsed).map(([key, value]) => [key, Number(value)])
-            );
-            return true;
+            return this.parseAndLoad(data);
         } catch (error) {
             dump("FolderSnapshotManager: 加载快照失败", error);
             return false;
@@ -161,14 +174,41 @@ export class FolderSnapshotManager {
     }
 
     /**
-     * 保存快照到 localStorage
+     * 解析快照数据并装入 this.snapshotMap
+     */
+    private parseAndLoad(data: string): boolean {
+        try {
+            const parsed = JSON.parse(data) as Record<string, number>;
+            this.snapshotMap = new Map(
+                Object.entries(parsed).map(([key, value]) => [key, Number(value)])
+            );
+            return true;
+        } catch (error) {
+            dump("FolderSnapshotManager: 解析快照数据失败", error);
+            return false;
+        }
+    }
+
+    /**
+     * 保存快照到 localStorage，同时镜像写入文件 (兜底移动端 localStorage 被清除)
      */
     private saveToStorage(): void {
+        let data: string;
         try {
             const obj = Object.fromEntries(this.snapshotMap);
-            this.plugin.app.saveLocalStorage(this.storageKey, JSON.stringify(obj));
+            data = JSON.stringify(obj);
+        } catch (error) {
+            dump("FolderSnapshotManager: 序列化快照失败", error);
+            return;
+        }
+
+        try {
+            this.plugin.app.saveLocalStorage(this.storageKey, data);
         } catch (error) {
             dump("FolderSnapshotManager: 保存快照失败", error);
         }
+
+        // 即使 localStorage 写入失败 (如配额)，镜像写入也照常进行
+        this.mirror.scheduleWrite(data);
     }
 }

--- a/src/lib/sync/operator_file.ts
+++ b/src/lib/sync/operator_file.ts
@@ -21,6 +21,30 @@ export let isPluginUnloading = false;
 // 会话 ID 到文件路径的映射，用于处理 463 会话不存在错误
 const sessionIdToPathMap = new Map<string, string>()
 
+// 大文件跳过同步通知去重：本会话内已提示过的 "path|size"，避免同一文件每轮同步重复弹 toast
+const sessionLargeFileNotified = new Set<string>()
+
+/**
+ * 大文件跳过同步的通知去重：同一 (path, size) 组合本会话或历史设置中已提示过则只 dump，不再弹 toast
+ * Dedup notice for large-file-skip: only dump (no toast) if this (path, size) pair was already notified
+ * either in this session or recorded in settings history
+ */
+function notifyLargeFileSkipped(plugin: FastSync, path: string, size: number, message: string): void {
+  const key = `${path}|${size}`
+  const shown = plugin.settings.largeFileNoticeShown ?? []
+  if (sessionLargeFileNotified.has(key) || shown.includes(key)) {
+    dump(`Large file skip notice suppressed (already shown): ${key}`)
+    return
+  }
+  showSyncNotice(message, 5000)
+  sessionLargeFileNotified.add(key)
+  // 重新赋值而非 push：settings 可能与 DEFAULT_SETTINGS 浅拷贝共享同一数组引用，原地 push 会污染默认值
+  const next = [...shown, key]
+  if (next.length > 200) next.shift()
+  plugin.settings.largeFileNoticeShown = next
+  void plugin.saveSettings()
+}
+
 /**
  * 获取临时分片目录路径
  */
@@ -180,7 +204,7 @@ export const fileModify = async function (file: TAbstractFile, plugin: FastSync,
 
   if (isLargeBinarySyncRisk(file.stat.size, plugin)) {
     dump(`Skip file modify for large attachment (${describeBinarySyncLimit()} limit): ${file.path}`, file.stat.size)
-    showSyncNotice(`Fast Note Sync skipped large file: ${file.path}`, 5000)
+    notifyLargeFileSkipped(plugin, file.path, file.stat.size, `Fast Note Sync skipped large file: ${file.path}`)
     return
   }
 
@@ -440,7 +464,7 @@ export const receiveFileUpload = async function (data: FileUploadMessage, plugin
   }
   if (isLargeBinarySyncRisk(file.stat.size, plugin)) {
     dump(`Skip file upload for large attachment (${describeBinarySyncLimit()} limit): ${data.path}`, file.stat.size)
-    showSyncNotice(`Fast Note Sync skipped large file upload: ${data.path}`, 5000)
+    notifyLargeFileSkipped(plugin, data.path, file.stat.size, `Fast Note Sync skipped large file upload: ${data.path}`)
     plugin.fileSyncTasks.completed++
     return
   }
@@ -680,7 +704,7 @@ export const receiveFileSyncUpdate = async function (data: ReceiveFileSyncUpdate
   }
   if (isLargeBinarySyncRisk(data.size, plugin)) {
     dump(`Skip file download for large attachment (${describeBinarySyncLimit()} limit): ${data.path}`, data.size)
-    showSyncNotice(`Fast Note Sync skipped large file download: ${data.path}`, 5000)
+    notifyLargeFileSkipped(plugin, data.path, data.size, `Fast Note Sync skipped large file download: ${data.path}`)
     plugin.fileSyncTasks.completed++;
     return
   }

--- a/src/lib/utils/helpers.ts
+++ b/src/lib/utils/helpers.ts
@@ -628,6 +628,108 @@ export function debounce<T extends (...args: unknown[]) => unknown>(func: T, wai
 }
 
 /**
+ * =============================================================================
+ * 本地状态文件镜像 (Local State File Mirror)
+ * =============================================================================
+ */
+
+/**
+ * 本地状态文件镜像器：把某个纯 localStorage 状态额外镜像一份到 vault 内的文件，
+ * 用于移动端 WebView localStorage 被系统清除后的兜底恢复（文件哈希表/配置哈希表/目录快照等）。
+ * 镜像文件路径挂在插件目录下，构造时即通过 configAddPathExcluded 挡在配置同步之外
+ * (内存级排除，不依赖 localStorage，因此不会被同样的清除问题连带影响)。
+ * Local state file mirror: mirrors a piece of localStorage-only state into a file inside the vault,
+ * so it can be recovered after mobile WebView localStorage gets cleared by the system (file hash map /
+ * config hash map / folder snapshot, etc). The mirror path lives under the plugin dir and is excluded
+ * from config sync via configAddPathExcluded at construction time (in-memory exclusion, unaffected by
+ * the same localStorage-clearing issue).
+ */
+export class LocalStateFileMirror {
+  private plugin: FastSync;
+  private mirrorPath: string;
+  private latestData: string | null = null;
+  // 是否存在尚未落盘的最新数据 (Whether latestData hasn't been persisted yet)
+  private pendingWrite: boolean = false;
+  // 写入串行化：写入在途时不并发发起新写入，仅记下需要在写完后重跑一次
+  // Write serialization: don't start a concurrent write while one is in-flight; just remember to rerun once it finishes
+  private isWriting: boolean = false;
+  private rerunAfterWrite: boolean = false;
+  private writeTimer: number | null = null;
+
+  constructor(plugin: FastSync, fileName: string) {
+    this.plugin = plugin;
+    this.mirrorPath = `${getPluginDir(plugin)}/${fileName}`;
+    // 挡在配置同步之外，防止镜像文件本身被当作配置项同步
+    configAddPathExcluded(this.mirrorPath, plugin);
+  }
+
+  /**
+   * 读取镜像文件内容；不存在或异常均返回 null，绝不弹 toast
+   */
+  async read(): Promise<string | null> {
+    try {
+      const exists = await this.plugin.app.vault.adapter.exists(this.mirrorPath);
+      if (!exists) return null;
+      return await this.plugin.app.vault.adapter.read(this.mirrorPath);
+    } catch (error) {
+      dump(`LocalStateFileMirror: 读取镜像文件失败: ${this.mirrorPath}`, error);
+      return null;
+    }
+  }
+
+  /**
+   * 安排一次防抖写入 (2000ms)，latest-wins：期间多次调用只保留最新一份数据
+   */
+  scheduleWrite(data: string): void {
+    this.latestData = data;
+    this.pendingWrite = true;
+    if (this.writeTimer) window.clearTimeout(this.writeTimer);
+    this.writeTimer = window.setTimeout(() => {
+      this.writeTimer = null;
+      this.doWrite();
+    }, 2000);
+  }
+
+  /**
+   * 串行化落盘：写入在途时只标记需要重跑，绝不并发 adapter.write；写失败只 dump，不弹 toast
+   */
+  private doWrite(): void {
+    if (!this.pendingWrite || this.latestData === null) return;
+    if (this.isWriting) {
+      this.rerunAfterWrite = true;
+      return;
+    }
+    this.isWriting = true;
+    this.pendingWrite = false;
+    const data = this.latestData;
+    void this.plugin.app.vault.adapter.write(this.mirrorPath, data)
+      .catch((error) => {
+        dump(`LocalStateFileMirror: 写入镜像文件失败: ${this.mirrorPath}`, error);
+      })
+      .finally(() => {
+        this.isWriting = false;
+        if (this.rerunAfterWrite) {
+          this.rerunAfterWrite = false;
+          this.pendingWrite = true;
+          this.doWrite();
+        }
+      });
+  }
+
+  /**
+   * 若有未落盘的数据，取消防抖计时器并立即触发一次写入 (同步上下文调用，void 掉 promise)
+   */
+  flush(): void {
+    if (this.writeTimer) {
+      window.clearTimeout(this.writeTimer);
+      this.writeTimer = null;
+    }
+    if (!this.pendingWrite) return;
+    this.doWrite();
+  }
+}
+
+/**
  * 等待文件夹变为空
  */
 export const waitForFolderEmpty = async function (path: string, plugin: FastSync, timeoutMs: number = 10000): Promise<boolean> {

--- a/src/main.ts
+++ b/src/main.ts
@@ -620,6 +620,10 @@ export default class FastSync extends Plugin {
     // 取消注册文件事件
     void this.reloadServices(false)
     this.updateStatusBar("")
+    // 落盘防抖中的状态文件镜像写入 (Flush pending debounced state mirror writes)
+    this.fileHashManager?.flush()
+    this.configHashManager?.flush()
+    this.folderSnapshotManager?.flush()
   }
 
   async loadSettings() {

--- a/src/setting.tsx
+++ b/src/setting.tsx
@@ -110,6 +110,8 @@ export interface PluginSettings {
   hashSyncLimitEnabled: boolean
   /** 哈希计算数量限制 */
   hashSyncLimit: number
+  /** 已提示过大文件跳过同步的 "path|size" 记录，避免同一文件每轮同步重复弹通知 */
+  largeFileNoticeShown: string[]
 }
 
 /**
@@ -171,6 +173,7 @@ export const DEFAULT_SETTINGS: PluginSettings = {
   attachmentSyncLimit: 50,
   hashSyncLimitEnabled: false,
   hashSyncLimit: 50000,
+  largeFileNoticeShown: [],
 }
 
 export type TabId = "GENERAL" | "DISPLAY" | "SHORTCUT" | "REMOTE" | "SYNC" | "CLOUD" | "DEBUG"

--- a/tests/file-mirror-restore.test.mjs
+++ b/tests/file-mirror-restore.test.mjs
@@ -1,0 +1,181 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import vm from "node:vm";
+import ts from "typescript";
+
+// 冒烟测试：移动端 localStorage 被清除后，FileHashManager 应从文件镜像恢复而非全量重建
+// Smoke test: after mobile localStorage eviction, FileHashManager restores from the file mirror
+// instead of rebuilding (and re-notifying) from scratch.
+
+const root = path.resolve(import.meta.dirname, "..");
+
+function transpile(relPath) {
+  const sourcePath = path.join(root, relPath);
+  const source = fs.readFileSync(sourcePath, "utf8");
+  return ts.transpileModule(source, {
+    compilerOptions: {
+      module: ts.ModuleKind.CommonJS,
+      target: ts.ScriptTarget.ES2020,
+      esModuleInterop: true,
+    },
+    fileName: sourcePath,
+  }).outputText;
+}
+
+function loadModule(relPath, requireStub, extraGlobals = {}) {
+  const module = { exports: {} };
+  vm.runInNewContext(transpile(relPath), {
+    require: requireStub,
+    module,
+    exports: module.exports,
+    console,
+    window: { setTimeout, clearTimeout },
+    setTimeout,
+    clearTimeout,
+    ...extraGlobals,
+  });
+  return module.exports;
+}
+
+// --- 载入 helpers.ts（提供 LocalStateFileMirror / debounce 等） ---
+const helpersRequireStub = (id) => {
+  switch (id) {
+    case "obsidian":
+      return {
+        Notice: class { setMessage() {} hide() {} },
+        normalizePath: (p) => p,
+        TFolder: class {},
+        Platform: { isMobile: false },
+        App: class {},
+      };
+    case "../../i18n/lang":
+      return { $: (key) => key };
+    case "../../main":
+      return {};
+    case "../sync/sync_log_manager":
+      return { SyncLogManager: { getInstance: () => ({ addOrUpdateLog: () => undefined }) } };
+    case "../helpers_obsidian_bypass":
+      return {
+        nativeFetch: () => undefined,
+        vaultDelete: () => undefined,
+        dump: () => undefined,
+        dumpError: () => undefined,
+        setLogEnabled: () => undefined,
+        logLevel: () => undefined,
+      };
+    default:
+      throw new Error(`Unexpected require in helpers: ${id}`);
+  }
+};
+const helpers = loadModule("src/lib/utils/helpers.ts", helpersRequireStub, {
+  activeDocument: undefined,
+  crypto: { getRandomValues: (a) => a },
+});
+
+// --- 载入 file_hash_manager.ts ---
+const fhmRequireStub = (id) => {
+  switch (id) {
+    case "../utils/helpers":
+      return helpers;
+    case "../../main":
+      return {};
+    default:
+      throw new Error(`Unexpected require in file_hash_manager: ${id}`);
+  }
+};
+const { FileHashManager } = loadModule("src/lib/storage/file_hash_manager.ts", fhmRequireStub);
+
+// --- 假 plugin：localStorage 用 Map，vault.adapter 用 Map（内存文件系统） ---
+function makeFakePlugin(localStorageMap, fileMap, { onGetFiles } = {}) {
+  return {
+    manifest: { id: "fast-note-sync", dir: ".obsidian/plugins/fast-note-sync" },
+    settings: {},
+    app: {
+      loadLocalStorage: (key) => (localStorageMap.has(key) ? localStorageMap.get(key) : null),
+      saveLocalStorage: (key, value) => {
+        if (value === null || value === undefined) localStorageMap.delete(key);
+        else localStorageMap.set(key, String(value));
+      },
+      vault: {
+        configDir: ".obsidian",
+        getName: () => "TestVault",
+        getFiles: () => {
+          if (onGetFiles) onGetFiles();
+          return [];
+        },
+        adapter: {
+          exists: async (p) => fileMap.has(p),
+          read: async (p) => {
+            if (!fileMap.has(p)) throw new Error("ENOENT: " + p);
+            return fileMap.get(p);
+          },
+          write: async (p, data) => {
+            fileMap.set(p, data);
+          },
+        },
+      },
+    },
+  };
+}
+
+const MIRROR_PATH = ".obsidian/plugins/fast-note-sync/fileHashMap.json";
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+// === 场景 A：写入哈希 → flush → localStorage 与镜像文件都有数据 ===
+{
+  const ls = new Map();
+  const filesA = new Map();
+  const plugin = makeFakePlugin(ls, filesA);
+  const mgr = new FileHashManager(plugin);
+  await mgr.initialize(); // 双空 → 走重建（getFiles 返回空数组，静默完成）
+
+  mgr.setFileHash("notes/a.md", "hash-a", 111, 10);
+  mgr.setFileHash("img/b.png", "hash-b", 222, 20);
+  mgr.flush();
+  await sleep(20); // 等 adapter.write 异步落盘
+
+  assert.equal(ls.has("fns-fileHashMap"), true, "localStorage 应有稳定 key 数据");
+  assert.equal(filesA.has(MIRROR_PATH), true, "镜像文件应已写入");
+  const mirrored = JSON.parse(filesA.get(MIRROR_PATH));
+  assert.equal(mirrored["notes/a.md"].hash, "hash-a");
+  assert.equal(mirrored["img/b.png"].hash, "hash-b");
+
+  // === 场景 B：模拟移动端 localStorage 被系统清除 → 新实例应从镜像恢复，不重建 ===
+  ls.clear();
+  let rebuilt = false;
+  const plugin2 = makeFakePlugin(ls, filesA, { onGetFiles: () => { rebuilt = true; } });
+  const mgr2 = new FileHashManager(plugin2);
+  await mgr2.initialize();
+
+  assert.equal(rebuilt, false, "镜像命中时不应触发全量重建（不应调用 vault.getFiles）");
+  assert.equal(mgr2.getPathHash("notes/a.md"), "hash-a", "应从镜像恢复哈希");
+  assert.equal(mgr2.getValidHash("img/b.png", 222, 20), "hash-b", "mtime/size 应一并恢复");
+  assert.equal(ls.has("fns-fileHashMap"), true, "恢复后应回写 localStorage");
+}
+
+// === 场景 C：localStorage 与镜像均无 → 走重建路径（getFiles 被调用），不报错 ===
+{
+  const ls = new Map();
+  const files = new Map();
+  let rebuilt = false;
+  const plugin = makeFakePlugin(ls, files, { onGetFiles: () => { rebuilt = true; } });
+  const mgr = new FileHashManager(plugin);
+  await mgr.initialize();
+  assert.equal(rebuilt, true, "双空时应触发重建");
+  assert.equal(mgr.isReady(), true);
+}
+
+// === 场景 D：旧版绑定库名的 key 迁移到稳定 key ===
+{
+  const ls = new Map();
+  const files = new Map();
+  ls.set("fns-TestVault-fileHashMap", JSON.stringify({ "old/n.md": { hash: "h-old", mtime: 1, size: 2 } }));
+  const plugin = makeFakePlugin(ls, files);
+  const mgr = new FileHashManager(plugin);
+  await mgr.initialize();
+  assert.equal(mgr.getPathHash("old/n.md"), "h-old", "旧 key 数据应可读到");
+  assert.equal(ls.has("fns-fileHashMap"), true, "旧 key 数据应迁移到稳定 key");
+}
+
+console.log("file-mirror-restore.test.mjs: all scenarios passed");


### PR DESCRIPTION
## 问题

**1. 手机端每次打开 Obsidian 都全量重算哈希**

移动端 WebView 的 localStorage 会被系统清除（存储压力、系统回收等场景，iOS 上尤其常见）。而文件哈希表 / 配置哈希表 / 目录快照只存在 localStorage 里，丢失后每次启动都触发全量重建：反复弹「正在初始化文件哈希映射…」进度通知，大库上明显耗时耗电。实测手机端每次冷启动都复现。

**2. 大文件跳过同步的通知每次都弹**

超出大小限制的同一个文件，每轮同步都会重新弹一次 `Fast Note Sync skipped large file …` toast，长期存在的大文件会造成每次启动必弹的噪声。

## 修复

- 新增 `LocalStateFileMirror`（`helpers.ts`）：把三处 localStorage 状态镜像写入插件目录下的文件（`fileHashMap.json` / `configHashMap.json` / `folderSnapshot.json`）。写入 2s 防抖 + 串行化 latest-wins，绝不并发写；构造时通过 `configAddPathExcluded` 把镜像文件挡在配置同步之外（内存级排除，不受 localStorage 清除影响）。
- 三个 manager 的 `initialize()`：localStorage 未命中时先尝试从镜像恢复（不重建、不弹通知，并回写 localStorage），镜像也没有才真正重建。`saveToStorage()` 同步安排镜像写入——即使 localStorage 写入因配额失败，镜像也照常落盘。
- 存储键改为与 vault 名无关的稳定键（`fns-fileHashMap` 等），带由新到旧的历史键自动迁移。原因：iCloud 手机端同步冲突常把库文件夹改名（"Vault 1" 等），绑定库名的键改名即失效，同样造成意外重建。
- `onunload` 增加三个 manager 的镜像 flush，防止防抖窗口内的写入丢失。
- 大文件跳过通知按 `(path, size)` 去重：会话内存 Set + `data.json` 持久记录（上限 200 条），同一文件只提醒一次，之后仅记入 debug 日志。

## 测试

新增 `tests/file-mirror-restore.test.mjs`（`npm run test:mirror`，与现有 `test:auth` 同款 transpile+vm 模式），覆盖四个场景：

1. 写入哈希 → flush → localStorage 与镜像文件都有数据
2. 模拟 localStorage 被系统清除 → 新实例从镜像恢复，**不触发全量重建**、mtime/size 完整
3. localStorage 与镜像均无 → 正常走重建路径
4. 旧版绑定库名的键自动迁移到稳定键

`npm run build`（tsc + esbuild）与 eslint 均零错误。修复已在真机（iOS）验证：更新后冷启动不再重算哈希、不再弹进度通知。

> 说明：本 PR 基于当前 master 独立制作，与 #229 无依赖关系；两者都合并时会有少量相邻行冲突，需要的话我可以随时 rebase。

🤖 Generated with [Claude Code](https://claude.com/claude-code)