### PR TITLE
fix: debounce remote vault name changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "build": "tsc -noEmit -skipLibCheck && node esbuild.config.mjs production",
     "test:auth": "node tests/websocket-auth-error.test.mjs",
     "test:mirror": "node tests/file-mirror-restore.test.mjs",
+    "test:vault-name": "node tests/vault-name-setting.test.mjs",
     "ver": "node ./scripts/update-version.js",
     "dist": "npx tsx scripts/copy-dist.ts",
     "translate": "node scripts/translate-i18n.mjs --model Qwen/Qwen3.6-35B-A3B",

--- a/src/lib/settings/vault_name.ts
+++ b/src/lib/settings/vault_name.ts
@@ -1,0 +1,26 @@
+import { debounce } from "../utils/helpers";
+
+interface VaultNameSettingsOwner {
+  settings: { vault: string }
+  wsSettingChange: boolean
+  localStorageManager: { clearSyncTime(): void }
+  saveAndReloadServices(): Promise<void>
+}
+
+export function createVaultNameChangeHandler(plugin: VaultNameSettingsOwner, wait = 500): (value: string) => void {
+  let pendingValue = plugin.settings.vault
+  const applyPendingValue = debounce(async () => {
+    const value = pendingValue
+    if (value === plugin.settings.vault) return
+
+    plugin.wsSettingChange = true
+    plugin.settings.vault = value
+    plugin.localStorageManager.clearSyncTime()
+    await plugin.saveAndReloadServices()
+  }, wait)
+
+  return (value: string) => {
+    pendingValue = value
+    applyPendingValue()
+  }
+}

--- a/src/setting.tsx
+++ b/src/setting.tsx
@@ -14,6 +14,7 @@ import { AppWithInternal } from "./lib/utils/types";
 import { RuleEditor } from "./views/rule-editor";
 import { $ } from "./i18n/lang";
 import FastSync from "./main";
+import { createVaultNameChangeHandler } from "./lib/settings/vault_name";
 
 
 export interface PluginSettings {
@@ -1308,16 +1309,12 @@ export class SettingTab extends PluginSettingTab {
     )
     this.setDescWithBreaks(set.lastElementChild as HTMLElement, $("setting.remote.api_token_desc"))
 
+    const handleVaultNameChange = createVaultNameChangeHandler(this.plugin)
     new Setting(set).setName($("setting.remote.vault_name")).addText((text) =>
       text
         .setPlaceholder($("setting.remote.vault_name"))
         .setValue(this.plugin.settings.vault)
-        .onChange(async (value) => {
-          this.plugin.wsSettingChange = true
-          this.plugin.settings.vault = value
-          this.plugin.localStorageManager.clearSyncTime()
-          await this.plugin.saveAndReloadServices()
-        }),
+        .onChange(handleVaultNameChange),
     )
     this.setDescWithBreaks(set.lastElementChild as HTMLElement, $("setting.remote.vault_name_desc"))
 

--- a/tests/vault-name-setting.test.mjs
+++ b/tests/vault-name-setting.test.mjs
@@ -1,0 +1,77 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import vm from "node:vm";
+import ts from "typescript";
+
+const root = path.resolve(import.meta.dirname, "..");
+const sourcePath = path.join(root, "src", "lib", "settings", "vault_name.ts");
+const source = fs.readFileSync(sourcePath, "utf8");
+const transpiled = ts.transpileModule(source, {
+  compilerOptions: {
+    module: ts.ModuleKind.CommonJS,
+    target: ts.ScriptTarget.ES2022,
+  },
+}).outputText;
+
+const module = { exports: {} };
+const debounce = (func, wait) => {
+  let timeout;
+  return (...args) => {
+    clearTimeout(timeout);
+    timeout = setTimeout(() => func(...args), wait);
+  };
+};
+
+vm.runInNewContext(
+  transpiled,
+  {
+    module,
+    exports: module.exports,
+    require: (id) => {
+      if (id === "../utils/helpers") return { debounce };
+      throw new Error(`Unexpected import: ${id}`);
+    },
+  },
+  { filename: sourcePath },
+);
+
+const { createVaultNameChangeHandler } = module.exports;
+assert.equal(typeof createVaultNameChangeHandler, "function");
+
+let clearCount = 0;
+let saveCount = 0;
+const plugin = {
+  settings: { vault: "Original" },
+  wsSettingChange: false,
+  localStorageManager: {
+    clearSyncTime() {
+      clearCount += 1;
+    },
+  },
+  async saveAndReloadServices() {
+    saveCount += 1;
+  },
+};
+
+const handleVaultNameChange = createVaultNameChangeHandler(plugin, 20);
+handleVaultNameChange("N");
+handleVaultNameChange("Ne");
+handleVaultNameChange("New Vault");
+
+assert.equal(plugin.settings.vault, "Original");
+assert.equal(clearCount, 0);
+assert.equal(saveCount, 0);
+
+await new Promise((resolve) => setTimeout(resolve, 40));
+
+assert.equal(plugin.settings.vault, "New Vault");
+assert.equal(plugin.wsSettingChange, true);
+assert.equal(clearCount, 1);
+assert.equal(saveCount, 1);
+
+handleVaultNameChange("New Vault");
+await new Promise((resolve) => setTimeout(resolve, 40));
+
+assert.equal(clearCount, 1);
+assert.equal(saveCount, 1);


### PR DESCRIPTION
## What
- debounce remote vault name changes before updating plugin settings
- reload synchronization services once with the final typed value
- add a regression test covering rapid input changes

## Why
The settings input currently reloads services on every keystroke, which can create a separate remote vault for each intermediate name. Waiting for typing to settle prevents those intermediate vault creations.

## Tests
- `pnpm run test:vault-name`
- `pnpm run test:mirror`
- `pnpm run lint`
- `pnpm run build`

Fixes #224